### PR TITLE
Process string instead of file, fixes issue with `broccoli serve`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -102,7 +102,7 @@ EslintValidationFilter.prototype.write = function write(readTree, destDir) {
 
 EslintValidationFilter.prototype.processString = function processString(content, relativePath) {
   // verify file content
-  var result = this.cli.executeOnFiles([this.eslintrc + '/' + relativePath]);
+  var result = this.cli.executeOnText(content, relativePath);
   var filteredResults = filterAllIgnoredFileMessages(result);
 
   // if verification has result


### PR DESCRIPTION
```bash
node -v                                # v0.10.36
npm view broccoli-lint-eslint version  # 1.0.1
```
This pull request fixes the following problem:

When running `broccoli serve` on one of my projects, I get expected output the first run, but as soon as I edit an affected file, I get the following error message:
```
Built with error:
File: index.js
Error: ENOENT, no such file or directory '/path/tmp/static_compiler-tmp_dest_dir-eUVwYQrn.tmp/index.js'
    at Object.fs.statSync (fs.js:696:18)
    at walk (/path/node_modules/broccoli-lint-eslint/node_modules/eslint/lib/util/traverse.js:36:15)
    at /path/node_modules/broccoli-lint-eslint/node_modules/eslint/lib/util/traverse.js:102:9
    at Array.forEach (native)
    at traverse (/path/node_modules/broccoli-lint-eslint/node_modules/eslint/lib/util/traverse.js:101:11)
    at CLIEngine.executeOnFiles (/path/node_modules/broccoli-lint-eslint/node_modules/eslint/lib/cli-engine.js:323:9)
    at EslintValidationFilter.processString (/path/node_modules/broccoli-lint-eslint/lib/index.js:105:25)
    at EslintValidationFilter.Filter.processFile (/path/node_modules/broccoli-lint-eslint/node_modules/broccoli-filter/index.js:136:31)
    at Promise.resolve.then.catch.err.file (/path/node_modules/broccoli-lint-eslint/node_modules/broccoli-filter/index.js:85:21)
    at lib$rsvp$$internal$$tryCatch (/path/node_modules/broccoli-lint-eslint/node_modules/broccoli-filter/node_modules/rsvp/dist/rsvp.js:489:16)
```

The reason seems to be that `broccoli-lint-eslint` holds on to a source directory that's only used a single time. A few more lines could probably be removed with this pull request, but since I don't understand what their goal is, I didn't want to touch them.