### PR TITLE
Ideas for bolstering ignored-file tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "nightmare-mode/node",
   "rules": {
+    "arrow-body-style": [2, "as-needed"],
     "arrow-parens": [2, "always"],
     "no-console": 0,
     "prefer-arrow-callback": 0,

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,12 +35,7 @@ function getResultSeverity(result) {
 function filterIgnoredFileMessages(errors) {
   const ignoreRegex = /File ignored because of a matching ignore pattern\. Use --no-ignore to override\./;
 
-  return errors.filter((error) => {
-    if (error.message.match(ignoreRegex)) {
-      return false;
-    }
-    return true;
-  });
+  return errors.filter((error) => !error.message.match(ignoreRegex));
 }
 
 /**
@@ -49,13 +44,14 @@ function filterIgnoredFileMessages(errors) {
  * @returns {Object} filtered results
  */
 function filterAllIgnoredFileMessages(result) {
-  const resultOutput = result;
+  return {
+    results: result.results.map((resultItem) => {
+      const clonedItem = JSON.parse(JSON.stringify(resultItem));
 
-  result.results.forEach((resultItem) => {
-    resultItem.messages = filterIgnoredFileMessages(resultItem.messages);
-  });
-
-  return resultOutput;
+      clonedItem.messages = filterIgnoredFileMessages(clonedItem.messages);
+      return clonedItem;
+    })
+  };
 }
 
 function resolveInputDirectory(inputNode) {
@@ -129,20 +125,21 @@ EslintValidationFilter.prototype.processString = function processString(content,
   // verify file content
   const configPath = path.join(this.eslintrc, relativePath);
   const output = this.cli.executeOnText(content, configPath);
+
+  // print all verification results
+  if (output.results.length &&
+      output.results[0].messages.length) {
+    // log formatter output
+    console.log(this.formatter(output.results));
+  }
+
   const filteredOutput = filterAllIgnoredFileMessages(output);
 
-  // if verification has result
-  if (filteredOutput.results.length &&
-      filteredOutput.results[0].messages.length) {
-
-    // log formatter output
-    console.log(this.formatter(filteredOutput.results));
-
-    if (getResultSeverity(filteredOutput.results) > 0) {
-      if ('throwOnError' in this.internalOptions && this.internalOptions.throwOnError === true) {
-        // throw error if severe messages exist
-        throw new Error('severe rule errors');
-      }
+  // handle verification failure
+  if (getResultSeverity(filteredOutput.results) > 0) {
+    if ('throwOnError' in this.internalOptions && this.internalOptions.throwOnError === true) {
+      // throw error if severe messages exist
+      throw new Error('severe rule errors');
     }
   }
 

--- a/test/fixture/5.js
+++ b/test/fixture/5.js
@@ -1,0 +1,1 @@
+// A file that PASSES linting.


### PR DESCRIPTION
Includes a change that forwards previously filtered warnings to the console (but not to the test generator).

Thoughts?
