### PR TITLE
Improve logic that filters out error messages related to ignored files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.3.0 / 2016-05-18
+- Update to ESLint 2.10.2
+- Improve logic that filters out [error messages related to ignored files](https://github.com/eslint/eslint/blob/2166ad475bf58a4c1fa11d5c595598d17574ffd9/lib/cli-engine.js#L305)
+  - We now make sure we account for both files that are ignored by default, and files that are ignored because of a matching ignore pattern.
+
 # 2.2.1 / 2016-04-20
 - Escape path separator in RegExp used for finding directory paths (was causing issues in Windows).
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,8 @@ const md5Hex = require('md5-hex');
 const stringify = require('json-stable-stringify');
 const path = require('path');
 const escapeStringRegexp = require('escape-string-regexp');
-const BUILD_DIR_REGEX = new RegExp('(' + escapeStringRegexp(path.sep) + ')?build(' + escapeStringRegexp(path.sep) + ')?$');
+const BUILD_DIR_REGEXP = new RegExp('(' + escapeStringRegexp(path.sep) + ')?build(' + escapeStringRegexp(path.sep) + ')?$');
+const IGNORED_FILE_MESSAGE_REGEXP = /(?:File ignored by default\.)|(?:File ignored because of a matching ignore pattern\.)/;
 
 
 /**
@@ -38,14 +39,7 @@ function getResultSeverity(result) {
  * @returns {Array} filtered errors
  */
 function filterIgnoredFileMessages(errors) {
-  const ignoreRegex = /File ignored because of a matching ignore pattern\. Use --no-ignore to override\./;
-
-  return errors.filter((error) => {
-    if (error.message.match(ignoreRegex)) {
-      return false;
-    }
-    return true;
-  });
+  return errors.filter((error) => !IGNORED_FILE_MESSAGE_REGEXP.test(error.message));
 }
 
 /**
@@ -56,7 +50,7 @@ function filterIgnoredFileMessages(errors) {
 function filterAllIgnoredFileMessages(result) {
   const resultOutput = result;
 
-  result.results.forEach((resultItem) => {
+  resultOutput.results.forEach((resultItem) => {
     resultItem.messages = filterIgnoredFileMessages(resultItem.messages);
   });
 
@@ -135,7 +129,7 @@ EslintValidationFilter.prototype.extensions = ['js'];
 EslintValidationFilter.prototype.targetExtension = 'js';
 
 EslintValidationFilter.prototype.baseDir = function baseDir() {
-  return __dirname.replace(BUILD_DIR_REGEX, '');
+  return __dirname.replace(BUILD_DIR_REGEXP, '');
 };
 
 EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProcessString(content, relativePath) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "broccoli-persistent-filter": "^1.2.0",
     "escape-string-regexp": "^1.0.5",
-    "eslint": "^2.4.0",
+    "eslint": "^2.10.0",
     "json-stable-stringify": "^1.0.1",
     "md5-hex": "^1.2.1"
   },

--- a/test/main-tests/test.js
+++ b/test/main-tests/test.js
@@ -15,6 +15,7 @@ const CUSTOM_RULES = 'testing custom rules';
 const DOUBLEQUOTE = 'Strings must use doublequote.';
 const FILEPATH = 'fixture/1.js';
 const TEST_IGNORE_PATH = path.resolve(process.cwd(), './test/main-tests/fixture/.eslintignore');
+const IGNORED_FILE_MESSAGE_REGEXP = /(?:File ignored by default\.)|(?:File ignored because of a matching ignore pattern\.)/;
 const JS_FIXTURES = fs.readdirSync(FIXTURES).filter((name) => /\.js$/.test(name));
 
 describe('EslintValidationFilter', function describeEslintValidationFilter() {
@@ -82,7 +83,7 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
     return promise
       .then(function assertLinting({buildLog}) {
         expect(buildLog)
-        .to.not.match(/File ignored because of a matching ignore pattern\. Use --no-ignore to override\./);
+        .to.not.match(IGNORED_FILE_MESSAGE_REGEXP);
       });
   });
 
@@ -97,7 +98,7 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
     return promise
       .then(function assertLinting({buildLog}) {
         expect(buildLog)
-        .to.not.match(/File ignored because of a matching ignore pattern\. Use --no-ignore to override\./);
+        .to.not.match(IGNORED_FILE_MESSAGE_REGEXP);
       });
   });
 


### PR DESCRIPTION
This PR improves the logic that filters out [error messages related to ignored files](https://github.com/eslint/eslint/blob/2166ad475bf58a4c1fa11d5c595598d17574ffd9/lib/cli-engine.js#L305) to make sure that we're accounting for both files that are ignored by default, and files that are ignored because of a matching ignore pattern (While I was at it, I swapped out the usage of `String.prototype.match` with `RegExp.prototype.test`. Since we’re just testing for existence, this could stand to perform considerably faster.)

It also updates the version of ESLint to 2.10.2.

Most immediately, these changes should fix the [errors being experienced by users of the latest `ember-cli-eslint` release](https://github.com/ember-cli/ember-cli-eslint/issues/63). Due to the upgraded `eslint`, though, I'd like to publish a minor version update (2.3.0) after the merge.