### PR TITLE
Allow the testGenerator function to handle warnings.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -159,13 +159,10 @@ EslintValidationFilter.prototype.processString = function processString(content,
   };
 
   if (this.testGenerator) {
-    let messages = [];
+    const result = filteredOutput.results[0];
+    const messages = result.messages;
 
-    if (filteredOutput.results.length) {
-      messages = filteredOutput.results[0].messages || [];
-    }
-
-    toCache.output = this.testGenerator(relativePath, messages);
+    toCache.output = this.testGenerator(relativePath, messages, result);
   }
 
   return toCache;


### PR DESCRIPTION
Instead of only passing messages through, this now passes the full result object into the `testGenerator` function.  This allows the `testGenerator` function to decide how to handle warnings versus errors.

An additional argument was added to allow this change to be backwards compatible, but we should likely remove the middle argument when we are ready for a major version bump.

Fixes #10.