### PR TITLE
Bump ESLint version to 2.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "broccoli-persistent-filter": "^1.2.0",
     "escape-string-regexp": "^1.0.5",
-    "eslint": "^2.10.0",
+    "eslint": "^2.13.0",
     "json-stable-stringify": "^1.0.1",
     "md5-hex": "^1.2.1"
   },


### PR DESCRIPTION
In advance of [getting set for ESLint 3.x support](https://github.com/ember-cli/broccoli-lint-eslint/issues/40), this PR updates us to the last release for 2.x ([2.13.1](https://github.com/eslint/eslint/releases/tag/v2.13.1)) before we move future 2.x support onto a [branch outside of master](https://github.com/ember-cli/broccoli-lint-eslint/tree/2.x). 

There aren't any breaking changes since `2.10.0`, so this would just be a minor version bump before we start publishing 3.x releases.