### PR TITLE
Fix throwOnError option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ var outputNode = eslint(inputNode, options);
 * `inputNode` A [Broccoli node](https://github.com/broccolijs/broccoli/blob/master/docs/node-api.md)
 
 * `options` {Object}
+
   * `format` {string|function}: The path, or function reference, to a custom formatter (See [eslint/tree/master/lib/formatters](https://github.com/eslint/eslint/tree/master/lib/formatters) for alternatives).
 
     Default: `'eslint/lib/formatters/stylish'`
@@ -56,22 +57,26 @@ var outputNode = eslint(inputNode, options);
     var path = require('path');
 
     function testGenerator(relativePath, errors) {
-      return "module('" + path.dirname(relativePath) + '");";
-             "test('" + relativePath + "' should pass jshint', function() { " +
-             "  ok(passed, moduleName+" should pass jshint."+(errors ? "\n"+errors : '')); " +
-             "});
+      return "module('" + path.dirname(relativePath) + "');" +
+             "test('" + relativePath + "' should pass eslint', function() { " +
+             "  ok(passed, moduleName" + "should pass eslint." + (errors ? "\n" + errors : "") + ");  " +
+             "});"
     };
 
     return eslint(inputNode, {
       options: {
-        configFile: this.jshintrc.app + '/eslint.json',
-        rulesdir: this.jshintrc.app
+        configFile: this.eslintrc.app + '/eslint.json',
+        rulesdir: this.eslintrc.app
       },
       testGenerator: testGenerator
     });
     ```
 
   * `throwOnError` {boolean}: Cause exception error on first severe error.
+
+    Default: `false`
+
+  * `persist` {boolean}: Persist the state of filter output across restarts
 
     Default: `false`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,19 +15,18 @@ const IGNORED_FILE_MESSAGE_REGEXP = /(?:File ignored by default\.)|(?:File ignor
  * @param {Array} result Eslint verify result array
  * @returns {Number} If the returned number is greater than 0 the result contains errors.
  */
-function getResultSeverity(result) {
-
+function getResultSeverity(resultMessages = []) {
   // count all errors
-  return result.reduce((previous, message) => {
+  return resultMessages.reduce((totalSeverity, message) => {
     if (message.fatal) {
-      return previous + 1;
+      return totalSeverity + 1;
     }
 
     if (message.severity === 2) {
-      return previous + 1;
+      return totalSeverity + 1;
     }
 
-    return previous;
+    return totalSeverity;
   }, 0);
 }
 
@@ -78,18 +77,18 @@ function resolveInputDirectory(inputNode) {
 }
 
 /**
- * Uses the content of each file in a given tree and runs eslint validation on it.
- * @param {Object} inputNode Tree from broccoli.makeTree
+ * Uses the content of each file in a given node and runs eslint validation on it.
+ * @param {Object} inputNode Node from broccoli.makeTree
  * @param {{config: String, rulesdir: String, format: String}} options Filter options
  * @returns {EslintValidationFilter} Filter obconfig @constructor
  */
-function EslintValidationFilter(inputNode, options) {
+function EslintValidationFilter(inputNode, options = {}) {
   if (!(this instanceof EslintValidationFilter)) {
     return new EslintValidationFilter(inputNode, options);
   }
 
-  this.options = options || {};
-  const eslintOptions = this.options.options || {};
+  this.internalOptions = options;
+  const eslintOptions = options.options || {};
 
   // default ignore:true option
   if (typeof eslintOptions.ignore === 'undefined') {
@@ -97,19 +96,19 @@ function EslintValidationFilter(inputNode, options) {
   }
 
   // default is to persist filter output
-  if (typeof this.options.persist === 'undefined') {
-    this.options.persist = true;
+  if (typeof this.internalOptions.persist === 'undefined') {
+    this.internalOptions.persist = true;
   }
 
   // call base class constructor
-  Filter.call(this, inputNode, this.options);
+  Filter.call(this, inputNode, this.internalOptions);
 
   // set formatter
-  if (typeof this.options.format === 'function') {
-    this.formatter = this.options.format;
+  if (typeof this.internalOptions.format === 'function') {
+    this.formatter = this.internalOptions.format;
   } else {
     // eslint-disable-next-line global-require
-    this.formatter = require(this.options.format || 'eslint/lib/formatters/stylish');
+    this.formatter = require(this.internalOptions.format || 'eslint/lib/formatters/stylish');
   }
 
   this.console = options.console || console;
@@ -118,7 +117,7 @@ function EslintValidationFilter(inputNode, options) {
 
   this.eslintrc = resolveInputDirectory(inputNode);
 
-  this.testGenerator = this.options.testGenerator;
+  this.testGenerator = this.internalOptions.testGenerator;
   if (this.testGenerator) {
     this.targetExtension = 'lint-test.js';
   }
@@ -145,7 +144,7 @@ EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProces
   return md5Hex([
     content,
     relativePath,
-    stringify(this.options, {replacer: functionStringifier}),
+    stringify(this.internalOptions, {replacer: functionStringifier}),
     stringify(this.cli.getConfigForFile(path.join(this.eslintrc, relativePath)))
   ]);
 };
@@ -153,15 +152,13 @@ EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProces
 EslintValidationFilter.prototype.processString = function processString(content, relativePath) {
   // verify file content
   const configPath = path.join(this.eslintrc, relativePath);
-  const output = this.cli.executeOnText(content, configPath);
-  const filteredOutput = filterAllIgnoredFileMessages(output);
-  const toCache = {
-    lint: output,
-    output: content
-  };
+  const report = this.cli.executeOnText(content, configPath);
+  const filteredReport = filterAllIgnoredFileMessages(report);
 
-  if (this.testGenerator && Array.isArray(filteredOutput.results)) {
-    const result = filteredOutput.results[0] || {};
+  const toCache = { report, output: content };
+
+  if (this.testGenerator && Array.isArray(filteredReport.results)) {
+    const result = filteredReport.results[0] || {};
     const messages = result.messages || [];
 
     toCache.output = this.testGenerator(relativePath, messages, result);
@@ -170,21 +167,32 @@ EslintValidationFilter.prototype.processString = function processString(content,
   return toCache;
 };
 
-EslintValidationFilter.prototype.postProcess = function postProcess(fromCache) {
-  const lint = fromCache.lint;
-  const output = fromCache.output;
+/**
+ * Post-process the filtered output, calculating the result severity from the report
+ * if the option to `throwOnError` has been set
+ *
+ * @param {Object} results A results object returned from `processString` containing
+ * the following properties:
+ *    report {Object}: The report returned from this.cli.executeOnText()
+ *    output {string}: The original file content passed to `processString` -- or the
+ *      result of executing the a provided `testGenerator` function on the `report`
+ *
+ * @returns {Object} An object with an `.output` property, which will be
+ *    used as the emitted file contents
+ */
+EslintValidationFilter.prototype.postProcess = function postProcess({ report, output } /* , relativePath */) {
 
   // if verification has result
-  if (lint.results.length &&
-      lint.results[0].messages.length) {
+  if (report.results.length &&
+      report.results[0].messages.length) {
 
     // log formatter output
-    this.console.log(this.formatter(lint.results));
+    this.console.log(this.formatter(report.results));
 
-    if (getResultSeverity(lint.results) > 0) {
-      if ('throwOnError' in this.internalOptions && this.internalOptions.throwOnError === true) {
+    if ('throwOnError' in this.internalOptions && this.internalOptions.throwOnError === true) {
+      if (getResultSeverity(report.results[0].messages) > 0) {
         // throw error if severe messages exist
-        throw new Error('severe rule errors');
+        throw new Error('rules violation with `error` severity level');
       }
     }
   }

--- a/test/helpers/run-eslint.js
+++ b/test/helpers/run-eslint.js
@@ -15,10 +15,10 @@ module.exports = function runEslint(path, _options) {
   };
   options.options = options.options || {};
 
-  const tree = eslintValidationFilter(path, options);
-  const builder = new broccoli.Builder(tree);
+  const node = eslintValidationFilter(path, options);
+  const builder = new broccoli.Builder(node);
   const promise = builder.build().then(function builderThen() {
-    return { buildLog: buildLog.join('\n'), outputPath: tree.outputPath };
+    return { buildLog: buildLog.join('\n'), outputPath: node.outputPath };
   });
 
   promise.finally(function builderCleanup() {

--- a/test/main-tests/test.js
+++ b/test/main-tests/test.js
@@ -30,10 +30,10 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
     };
   });
 
-  function shouldReportErrors(inputTree, options) {
+  function shouldReportErrors(inputNode, options) {
     return function _shouldReportErrors() {
       // lint test fixtures
-      const promise = runEslint(inputTree, options);
+      const promise = runEslint(inputNode, options);
 
       return promise.then(function assertLinting({buildLog}) {
         expect(buildLog, 'Used eslint validation').to.have.string(RULE_TAG_CAMELCASE);
@@ -46,7 +46,7 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
   }
 
   // specify test fixtures via a broccoli node
-  const moveTree = mv(new UnwatchedDir(FIXTURES), 'foobar/fixture');
+  const moveNode = mv(new UnwatchedDir(FIXTURES), 'foobar/fixture');
 
   it('should report errors', shouldReportErrors(FIXTURES, {
     options: {
@@ -132,7 +132,7 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
     });
   });
 
-  it('should accept a node as the input', shouldReportErrors(moveTree, {
+  it('should accept a node as the input', shouldReportErrors(moveNode, {
     options: {
       ignore: false
     }
@@ -240,6 +240,20 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
       if (typeof eslintrcContent !== 'undefined') {
         fs.writeFileSync(eslintrcPath, eslintrcContent);
       }
+    });
+  });
+
+  it('throws when `throwOnError` is set and result severity', function() {
+    const promise = shouldReportErrors(FIXTURES, {
+      options: {
+        ignore: false,
+      },
+      throwOnError: true
+    })();
+
+    return promise.catch((err) => {
+      expect(err).to.be.an('error');
+      expect(err.message).to.equal('rules violation with `error` severity level');
     });
   });
 });


### PR DESCRIPTION
This PR fixes #7. It turns out there are 2 reasons that `throwOnError` was never being called:

1) In `postProcess`, we’re attempting to [read `throwOnError` from `this.internalOptions`](https://github.com/ember-cli/broccoli-lint-eslint/pull/44/files#diff-6d186b954a58d5bb740f73d84fe39073L183), which is actually `this.options`, so we never find it. That said, `internalOptions` does seem to be the clearer name (we’re working with both options for Broccoli and [options for ESLint](https://github.com/ember-cli/broccoli-lint-eslint/pull/44/files#diff-6d186b954a58d5bb740f73d84fe39073L91) — which, in the constructor, are set on... well... `options.options`), so I changed the `this.options` property that’s initialized in the constructor to `this.internalOptions`.

2) Once we do manage to detect the `throwOnError` setting, the [wrong input is being sent to `getResultSeverity`](https://github.com/ember-cli/broccoli-lint-eslint/pull/44/files#diff-6d186b954a58d5bb740f73d84fe39073L182), and so we never detect an `error` level violation. Passing in list of `messages` found on the first item in `report.results` here does the trick. (The test that allowed me to discover this can be played with [here](https://github.com/ember-cli/broccoli-lint-eslint/pull/44/files#diff-7f3bc9926f924d6bcc2b3573c4dfb89eR245).)