### PR TITLE
Update tests for mocha 3 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "broccoli-stew": "^1.2.0",
     "chai": "^3.5.0",
     "eslint-config-nightmare-mode": "^2.3.0",
-    "mocha": "^2.2.4",
+    "mocha": "^3.0.1",
     "rimraf": "^2.5.1",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"

--- a/test/file-format-tests/test.js
+++ b/test/file-format-tests/test.js
@@ -22,7 +22,7 @@ describe('Supporting different config file formats', function describeMultipleFo
 
     return new Promise((resolve) => {
 
-      it(`detects configuration files with the ${format} file type`, function configFileTypeSupport(done) {
+      it(`detects configuration files with the ${format} file type`, function configFileTypeSupport() {
         const filesPath = path.join(process.cwd(), 'test/file-format-tests/formats', format);
 
         const promise = runEslint(filesPath, {
@@ -34,7 +34,6 @@ describe('Supporting different config file formats', function describeMultipleFo
         return promise.then(function assertLinting({buildLog}) {
           expect(buildLog, 'Reported erroroneous single-quoted strings').to.have.string(MESSAGES.DOUBLEQUOTE);
           expect(buildLog, 'Reported erroroneous use of alert').to.have.string(MESSAGES.ALERT);
-          done();
         });
       });
     });


### PR DESCRIPTION
As the errors for #47 revealed, returning promises and using the `done` callback within the same test is now an [error in Mocha 3.x](https://github.com/mochajs/mocha/issues/2407). 

This PR cuts that out -- and gets us on Mocha 3.0.1 at the same time.