### PR TITLE
Avoid shipping test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   "author": "Jonathan Kingston",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jonathanKingston/broccoli-lint-eslint/issues"
+    "url": "https://github.com/ember-cli/broccoli-lint-eslint/issues"
   },
-  "homepage": "https://github.com/jonathanKingston/broccoli-lint-eslint",
+  "homepage": "https://github.com/ember-cli/broccoli-lint-eslint",
   "dependencies": {
     "broccoli-persistent-filter": "^1.2.0",
     "escape-string-regexp": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,7 @@
     "broccoli-plugin"
   ],
   "files": [
-    "build",
-    "lib",
-    "tests",
-    "conf"
+    "build/index.js"
   ],
   "author": "Jonathan Kingston",
   "license": "MIT",


### PR DESCRIPTION
Currently, all of the test source and compiled test files are shipped to NPM when the package is published.  In the spirit of keeping the download size as small as possible, we probably should just send of the `build/index.js` file.

I've checked it out and it seems like it should be safe to do this.  That file doens't do any relative imports, and is the `main` file according to the `package.json` so it's the only file that anyone consuming this library actually needs.