### PR TITLE
Use injected console object over global

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,8 +7,5 @@ module.exports = {
   },
   env: {
     node: true
-  },
-  rules: {
-    'no-console': 'off'
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,6 +112,8 @@ function EslintValidationFilter(inputNode, options) {
     this.formatter = require(this.options.format || 'eslint/lib/formatters/stylish');
   }
 
+  this.console = options.console || console;
+
   this.cli = new CLIEngine(eslintOptions);
 
   this.eslintrc = resolveInputDirectory(inputNode);
@@ -177,7 +179,7 @@ EslintValidationFilter.prototype.postProcess = function postProcess(fromCache) {
       lint.results[0].messages.length) {
 
     // log formatter output
-    console.log(this.formatter(lint.results));
+    this.console.log(this.formatter(lint.results));
 
     if (getResultSeverity(lint.results) > 0) {
       if ('throwOnError' in this.internalOptions && this.internalOptions.throwOnError === true) {


### PR DESCRIPTION
Discussed with @rwjblue awhile back. This PR requires that broccoli-lint-eslint use an injected `console` object over the `console` global. This way we can silence logging during ember-cli builds.

~~WIP until I can manually test with with an app and ember-cli-eslint.~~

This is backwards compatible and enables the ember-cli `--silent` option with https://github.com/ember-cli/ember-cli-eslint/pull/100.