### PR TITLE
Investigate ignore files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -183,11 +183,13 @@ EslintValidationFilter.prototype.processString = function processString(content,
 EslintValidationFilter.prototype.postProcess = function postProcess({ report, output } /* , relativePath */) {
 
   // if verification has result
-  if (report.results.length &&
-      report.results[0].messages.length) {
+  if (report.results.length && report.results[0].messages.length) {
 
     // log formatter output
-    this.console.log(this.formatter(report.results));
+    const results = this.formatter(report.results);
+    if (results) {
+      this.console.log(results);
+    }
 
     if ('throwOnError' in this.internalOptions && this.internalOptions.throwOnError === true) {
       if (getResultSeverity(report.results[0].messages) > 0) {

--- a/test/main-tests/test.js
+++ b/test/main-tests/test.js
@@ -14,6 +14,7 @@ const RULE_TAG_NO_CONSOLE = '(no-console)';
 const CUSTOM_RULES = 'testing custom rules';
 const DOUBLEQUOTE = 'Strings must use doublequote.';
 const FILEPATH = 'fixture/1.js';
+const FIXTURES_PATH = path.resolve(process.cwd(), FIXTURES);
 const TEST_IGNORE_PATH = path.resolve(process.cwd(), './test/main-tests/fixture/.eslintignore');
 const IGNORED_FILE_MESSAGE_REGEXP = /(?:File ignored by default\.)|(?:File ignored because of a matching ignore pattern\.)/;
 const JS_FIXTURES = fs.readdirSync(FIXTURES).filter((name) => /\.js$/.test(name));
@@ -71,33 +72,50 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
     });
   });
 
-  it('should use a default ignore:true option', function shouldAcceptDefaultIgnore() {
-    const promise = runEslint(FIXTURES, {
-      options: {
-        ignorePath: TEST_IGNORE_PATH
-      }
+  describe('ignoring files', function() {
+    it('should use a default ignore:true option', function shouldAcceptDefaultIgnore() {
+      const promise = runEslint(FIXTURES, {
+        options: {
+          ignorePath: TEST_IGNORE_PATH
+        }
+      });
+
+      return promise
+        .then(function assertLinting({ buildLog }) {
+          expect(buildLog).to.not.be.empty;
+          expect(buildLog).to.not.match(IGNORED_FILE_MESSAGE_REGEXP);
+        });
     });
 
-    return promise
-      .then(function assertLinting({buildLog}) {
-        expect(buildLog)
-        .to.not.match(IGNORED_FILE_MESSAGE_REGEXP);
+    it('should accept an ignore option', function shouldAcceptIgnoreOption() {
+      const promise = runEslint(FIXTURES, {
+        options: {
+          ignore: true,
+          ignorePath: TEST_IGNORE_PATH
+        }
       });
-  });
 
-  it('should accept an ignore option', function shouldAcceptIgnoreOption() {
-    const promise = runEslint(FIXTURES, {
-      options: {
-        ignore: true,
-        ignorePath: TEST_IGNORE_PATH
-      }
+      return promise
+        .then(function assertLinting({ buildLog }) {
+          expect(buildLog).to.not.be.empty;
+          expect(buildLog).to.not.match(IGNORED_FILE_MESSAGE_REGEXP);
+        });
     });
 
-    return promise
-      .then(function assertLinting({buildLog}) {
-        expect(buildLog)
-        .to.not.match(IGNORED_FILE_MESSAGE_REGEXP);
+    it('should work with an `.eslintignore` file', function shouldWorkWithEslintIgnoreFile() {
+      const promise = runEslint(FIXTURES, {
+        options: {
+          ignore: true,
+          cwd: FIXTURES_PATH
+        }
       });
+
+      return promise
+        .then(function assertLinting({ buildLog }) {
+          expect(buildLog).to.not.be.empty;
+          expect(buildLog).to.not.match(IGNORED_FILE_MESSAGE_REGEXP);
+        });
+    });
   });
 
   it('should accept config file path', function shouldAcceptConfigFile() {


### PR DESCRIPTION
In response to ember-cli/ember-cli-eslint#82 I added to and reorganized the tests a little bit.  Figured that the changes might as well end up back upstream.

Setting the timeout to `0` (never failing a test for taking too long) might not be a great solution long-term, but for now it's really annoying that the initial build takes a really long time and sometimes fails tests that would otherwise pass.  I'm going to try looking into what's actually causing that long initial build, but in the meantime it's nice not to have those tests failing intermittently. 