### PR TITLE
Add predefined test generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Example usage:
 var path = require('path');
 
 function testGenerator(relativePath, errors) {
-  return "module('" + path.dirname(relativePath) + '");";
-         "test('" + relativePath + "' should pass jshint', function() { " +
-         "  ok(passed, moduleName+" should pass jshint."+(errors ? "\n"+errors : '')); " +
+  return "module('" + path.dirname(relativePath) + "');";
+         "test('" + relativePath + "' should pass ESLint', function() { " +
+         "  ok(" + passed + ", " + moduleName + " should pass ESLint." + (errors ? "\n" + errors : '')); " +
          "});
 };
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The function receives the following arguments:
 - relativePath - The relative path to the file being tested.
 - errors - An array of eslint error objects found.
 
-If you provide a `string` one of the predefined test generators is used. Currently supported are `qunit` and `mocha`.
+If you provide a `string` one of the [predefined test generators](lib/test-generators.js) is used. Currently supported are `qunit` and `mocha`.
 
 Example usage:
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Path path to a custom formatter (See [eslint/tree/master/lib/formatters](https:/
 
 ##### testGenerator
 
-Type: `function`
+Type: `function` or `string`
 Default: `null`
 
 The function used to generate test modules. You can provide a custom function for your client side testing framework of choice.
@@ -49,6 +49,8 @@ The function receives the following arguments:
 
 - relativePath - The relative path to the file being tested.
 - errors - An array of eslint error objects found.
+
+If you provide a `string` one of the predefined test generators is used. Currently supported are `qunit` and `mocha`.
 
 Example usage:
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,10 @@ function filterAllIgnoredFileMessages(result) {
   return resultOutput;
 }
 
+function isString(x) {
+  return toString.call(x) === '[object String]';
+}
+
 function resolveInputDirectory(inputNode) {
   if (typeof inputNode === 'string') {
     return inputNode;
@@ -117,6 +121,19 @@ function EslintValidationFilter(inputNode, options) {
   this.eslintrc = resolveInputDirectory(inputNode);
 
   this.testGenerator = this.options.testGenerator;
+
+  if (isString(this.options.testGenerator)) {
+    const testGenerators = require('./test-generators');
+
+    this.testGenerator = testGenerators[this.options.testGenerator];
+    if (!this.testGenerator) {
+      throw new Error(`Could not find '${this.options.testGenerator}' test generator.`);
+    }
+
+  } else {
+    this.testGenerator = this.options.testGenerator;
+  }
+
   if (this.testGenerator) {
     this.targetExtension = 'lint-test.js';
   }

--- a/lib/test-generators.js
+++ b/lib/test-generators.js
@@ -1,0 +1,56 @@
+const escape = require('js-string-escape');
+
+function render(errors) {
+  return errors.map(function renderLine(error) {
+    return error.line + ':' + error.column + ' - ' + error.message + ' (' + error.ruleId + ')';
+  }).join('\n');
+}
+
+function qunit(relativePath, errors, results) {
+  const passed = !results.errorCount || results.errorCount.length === 0;
+
+  let messages = relativePath + ' should pass ESLint';
+
+  if (results.messages) {
+    messages += '\n\n' + render(results.messages);
+  }
+
+  return 'QUnit.module(\'ESLint | ' + escape(relativePath) + '\');\n' +
+    'QUnit.test(\'should pass ESLint\', function(assert) {\n' +
+    '  assert.expect(1);\n' +
+    '  assert.ok(' + passed + ', \'' + escape(messages) + '\');\n' +
+    '});\n';
+}
+
+function mocha(relativePath, errors, results) {
+  const passed = !results.errorCount || results.errorCount.length === 0;
+
+  let messages = relativePath + ' should pass ESLint';
+
+  if (results.messages) {
+    messages += '\n\n' + render(results.messages);
+  }
+
+  let output =
+    'describe(\'ESLint | ' + escape(relativePath) + '\', function() {\n' +
+    '  it(\'should pass ESLint\', function() {\n';
+
+  if (passed) {
+    output +=
+      '    // ESLint passed\n';
+  } else {
+    output +=
+      '    // ESLint failed\n' +
+      '    var error = new chai.AssertionError(\'' + escape(messages) + '\');\n' +
+      '    error.stack = undefined;\n' +
+      '    throw error;\n';
+  }
+
+  output +=
+    '  });\n' +
+    '});\n';
+
+  return output;
+}
+
+module.exports = {qunit, mocha};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "broccoli-persistent-filter": "^1.2.0",
     "escape-string-regexp": "^1.0.5",
     "eslint": "^2.13.0",
+    "js-string-escape": "^1.0.1",
     "json-stable-stringify": "^1.0.1",
     "md5-hex": "^1.2.1"
   },

--- a/test/test-generators-test.js
+++ b/test/test-generators-test.js
@@ -1,0 +1,109 @@
+const expect = require('chai').expect;
+const testGenerators = require('../build/test-generators');
+
+const FAIL = {
+  errorCount: 1,
+  messages: [{
+    line: 42,
+    column: 13,
+    message: 'This is not a valid foo',
+    ruleId: 'validate-foo',
+  }, {
+    line: 123,
+    column: 1,
+    message: 'foobar',
+    ruleId: 'comma-dangle',
+  }],
+};
+
+describe('test-generators', function() {
+  describe('qunit', function() {
+    before(function() {
+      this.generate = testGenerators.qunit;
+    });
+
+    it('generates passing test for missing errorCount', function() {
+      expect(this.generate('some/file.js', null, {}).trim()).to.equal(`
+QUnit.module('ESLint | some/file.js');
+QUnit.test('should pass ESLint', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'some/file.js should pass ESLint');
+});`.trim());
+    });
+
+    it('generates passing test for errorCount == 0', function() {
+      expect(this.generate('some/file.js', null, { errorCount: 0 }).trim()).to.equal(`
+QUnit.module('ESLint | some/file.js');
+QUnit.test('should pass ESLint', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'some/file.js should pass ESLint');
+});`.trim());
+    });
+
+    it('generates passing test for errorCount == 1', function() {
+      expect(this.generate('some/file.js', null, { errorCount: 1 }).trim()).to.equal(`
+QUnit.module('ESLint | some/file.js');
+QUnit.test('should pass ESLint', function(assert) {
+  assert.expect(1);
+  assert.ok(false, 'some/file.js should pass ESLint');
+});`.trim());
+    });
+
+    it('renders error messages', function() {
+      expect(this.generate('some/file.js', null, FAIL).trim()).to.equal(`
+QUnit.module('ESLint | some/file.js');
+QUnit.test('should pass ESLint', function(assert) {
+  assert.expect(1);
+  assert.ok(false, 'some/file.js should pass ESLint\\n\\n42:13 - This is not a valid foo (validate-foo)\\n123:1 - foobar (comma-dangle)');
+});`.trim());
+    });
+  });
+
+  describe('mocha', function() {
+    before(function() {
+      this.generate = testGenerators.mocha;
+    });
+
+    it('generates passing test for missing errorCount', function() {
+      expect(this.generate('some/file.js', null, {}).trim()).to.equal(`
+describe('ESLint | some/file.js', function() {
+  it('should pass ESLint', function() {
+    // ESLint passed
+  });
+});`.trim());
+    });
+
+    it('generates passing test for errorCount == 0', function() {
+      expect(this.generate('some/file.js', null, { errorCount: 0 }).trim()).to.equal(`
+describe('ESLint | some/file.js', function() {
+  it('should pass ESLint', function() {
+    // ESLint passed
+  });
+});`.trim());
+    });
+
+    it('generates passing test for errorCount == 1', function() {
+      expect(this.generate('some/file.js', null, { errorCount: 1 }).trim()).to.equal(`
+describe('ESLint | some/file.js', function() {
+  it('should pass ESLint', function() {
+    // ESLint failed
+    var error = new chai.AssertionError('some/file.js should pass ESLint');
+    error.stack = undefined;
+    throw error;
+  });
+});`.trim());
+    });
+
+    it('renders error messages', function() {
+      expect(this.generate('some/file.js', null, FAIL).trim()).to.equal(`
+describe('ESLint | some/file.js', function() {
+  it('should pass ESLint', function() {
+    // ESLint failed
+    var error = new chai.AssertionError('some/file.js should pass ESLint\\n\\n42:13 - This is not a valid foo (validate-foo)\\n123:1 - foobar (comma-dangle)');
+    error.stack = undefined;
+    throw error;
+  });
+});`.trim());
+    });
+  });
+});


### PR DESCRIPTION
We should cover the most common use cases of this lib by having a predefined Mocha and QUnit test generator in this package. If you use `testGenerator: 'mocha'` it will now automatically generate tests for Mocha.

This would get rid of e.g. https://github.com/switchfly/ember-mocha/blob/04aa8f72e2d6ce65b0d760bd3d8734ea578012bd/ember-cli-build.js#L161-L180 and I'm sure there is similar and potentially broken code in a lot of other projects too.

/cc @BrianSipple @alexlafroscia @rwjblue 