### PR TITLE
[2.x] Fix throwOnError support and add test

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,19 +15,14 @@ const IGNORED_FILE_MESSAGE_REGEXP = /(?:File ignored by default\.)|(?:File ignor
  * @param {Array} result Eslint verify result array
  * @returns {Number} If the returned number is greater than 0 the result contains errors.
  */
-function getResultSeverity(result) {
+function getResultSeverity(resultMessages = []) {
+  return resultMessages.reduce((accumulatedSeverity, message) => {
 
-  // count all errors
-  return result.reduce((previous, message) => {
-    if (message.fatal) {
-      return previous + 1;
+    if (message.fatal || message.severity === 2) {
+      return accumulatedSeverity + 1;
     }
 
-    if (message.severity === 2) {
-      return previous + 1;
-    }
-
-    return previous;
+    return accumulatedSeverity;
   }, 0);
 }
 
@@ -87,13 +82,13 @@ function resolveInputDirectory(inputNode) {
  * @param {{config: String, rulesdir: String, format: String}} options Filter options
  * @returns {EslintValidationFilter} Filter obconfig @constructor
  */
-function EslintValidationFilter(inputNode, options) {
+function EslintValidationFilter(inputNode, options = {}) {
   if (!(this instanceof EslintValidationFilter)) {
     return new EslintValidationFilter(inputNode, options);
   }
 
-  this.options = options || {};
-  const eslintOptions = this.options.options || {};
+  this.internalOptions = options || {};
+  const eslintOptions = options.options || {};
 
   // default ignore:true option
   if (typeof eslintOptions.ignore === 'undefined') {
@@ -101,19 +96,19 @@ function EslintValidationFilter(inputNode, options) {
   }
 
   // default is to persist filter output
-  if (typeof this.options.persist === 'undefined') {
-    this.options.persist = true;
+  if (typeof this.internalOptions.persist === 'undefined') {
+    this.internalOptions.persist = true;
   }
 
   // call base class constructor
-  Filter.call(this, inputNode, this.options);
+  Filter.call(this, inputNode, this.internalOptions);
 
   // set formatter
-  if (typeof this.options.format === 'function') {
-    this.formatter = this.options.format;
+  if (typeof this.internalOptions.format === 'function') {
+    this.formatter = this.internalOptions.format;
   } else {
     // eslint-disable-next-line global-require
-    this.formatter = require(this.options.format || 'eslint/lib/formatters/stylish');
+    this.formatter = require(this.internalOptions.format || 'eslint/lib/formatters/stylish');
   }
 
   this.console = options.console || console;
@@ -122,18 +117,18 @@ function EslintValidationFilter(inputNode, options) {
 
   this.eslintrc = resolveInputDirectory(inputNode);
 
-  this.testGenerator = this.options.testGenerator;
+  this.testGenerator = this.internalOptions.testGenerator;
 
-  if (isString(this.options.testGenerator)) {
+  if (isString(this.internalOptions.testGenerator)) {
     const testGenerators = require('./test-generators');
 
-    this.testGenerator = testGenerators[this.options.testGenerator];
+    this.testGenerator = testGenerators[this.internalOptions.testGenerator];
     if (!this.testGenerator) {
-      throw new Error(`Could not find '${this.options.testGenerator}' test generator.`);
+      throw new Error(`Could not find '${this.internalOptions.testGenerator}' test generator.`);
     }
 
   } else {
-    this.testGenerator = this.options.testGenerator;
+    this.testGenerator = this.internalOptions.testGenerator;
   }
 
   if (this.testGenerator) {
@@ -162,7 +157,7 @@ EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProces
   return md5Hex([
     content,
     relativePath,
-    stringify(this.options, {replacer: functionStringifier}),
+    stringify(this.internalOptions, { replacer: functionStringifier }),
     stringify(this.cli.getConfigForFile(path.join(this.eslintrc, relativePath)))
   ]);
 };
@@ -170,15 +165,13 @@ EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProces
 EslintValidationFilter.prototype.processString = function processString(content, relativePath) {
   // verify file content
   const configPath = path.join(this.eslintrc, relativePath);
-  const output = this.cli.executeOnText(content, configPath);
-  const filteredOutput = filterAllIgnoredFileMessages(output);
-  const toCache = {
-    lint: output,
-    output: content
-  };
+  const report = this.cli.executeOnText(content, configPath);
+  const filteredReport = filterAllIgnoredFileMessages(report);
 
-  if (this.testGenerator && Array.isArray(filteredOutput.results)) {
-    const result = filteredOutput.results[0] || {};
+  const toCache = { report, output: content };
+
+  if (this.testGenerator && Array.isArray(filteredReport.results)) {
+    const result = filteredReport.results[0] || {};
     const messages = result.messages || [];
 
     toCache.output = this.testGenerator(relativePath, messages, result);
@@ -187,28 +180,38 @@ EslintValidationFilter.prototype.processString = function processString(content,
   return toCache;
 };
 
-EslintValidationFilter.prototype.postProcess = function postProcess(fromCache) {
-  const lint = fromCache.lint;
-  const output = fromCache.output;
 
-  // if verification has result
-  if (lint.results.length && lint.results[0].messages.length) {
+/**
+ * Post-process the filtered output, calculating the result severity from the report
+ * if the option to `throwOnError` has been set
+ *
+ * @param {Object} results A results object returned from `processString` containing
+ * the following properties:
+ *    report {Object}: The report returned from this.cli.executeOnText()
+ *    output {string}: The original file content passed to `processString` -- or the
+ *      result of executing the a provided `testGenerator` function on the `report`
+ *
+ * @returns {Object} An object with an `.output` property, which will be
+ *    used as the emitted file contents
+ */
+ EslintValidationFilter.prototype.postProcess = function postProcess({ report, output } /* , relativePath */) {
 
-    // log formatter output
-    const results = this.formatter(lint.results);
-    if (results) {
-      this.console.log(results);
-    }
+   // if verification has result
+   if (report.results.length &&
+       report.results[0].messages.length) {
 
-    if (getResultSeverity(lint.results) > 0) {
-      if ('throwOnError' in this.internalOptions && this.internalOptions.throwOnError === true) {
-        // throw error if severe messages exist
-        throw new Error('severe rule errors');
-      }
-    }
-  }
+     // log formatter output
+     this.console.log(this.formatter(report.results));
 
-  return {
-    output
-  };
+     if ('throwOnError' in this.internalOptions && this.internalOptions.throwOnError === true) {
+       if (getResultSeverity(report.results[0].messages) > 0) {
+         // throw error if severe messages exist
+         throw new Error('rules violation with `error` severity level');
+       }
+     }
+   }
+
+   return {
+     output
+   };
 };

--- a/test/helpers/run-eslint.js
+++ b/test/helpers/run-eslint.js
@@ -15,10 +15,10 @@ module.exports = function runEslint(path, _options) {
   };
   options.options = options.options || {};
 
-  const tree = eslintValidationFilter(path, options);
-  const builder = new broccoli.Builder(tree);
+  const node = eslintValidationFilter(path, options);
+  const builder = new broccoli.Builder(node);
   const promise = builder.build().then(function builderThen() {
-    return { buildLog: buildLog.join('\n'), outputPath: tree.outputPath };
+    return { buildLog: buildLog.join('\n'), outputPath: node.outputPath };
   });
 
   promise.finally(function builderCleanup() {

--- a/test/main-tests/test.js
+++ b/test/main-tests/test.js
@@ -40,10 +40,10 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
     this.sinon.restore();
   });
 
-  function shouldReportErrors(inputTree, options) {
+  function shouldReportErrors(inputNode, options) {
     return function _shouldReportErrors() {
       // lint test fixtures
-      const promise = runEslint(inputTree, options);
+      const promise = runEslint(inputNode, options);
 
       return promise.then(function assertLinting({buildLog}) {
         expect(buildLog, 'Used eslint validation').to.have.string(RULE_TAG_CAMELCASE);
@@ -56,7 +56,7 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
   }
 
   // specify test fixtures via a broccoli node
-  const moveTree = mv(new UnwatchedDir(FIXTURES), 'foobar/fixture');
+  const moveNode = mv(new UnwatchedDir(FIXTURES), 'foobar/fixture');
 
   it('should report errors', shouldReportErrors(FIXTURES, {
     options: {
@@ -142,7 +142,7 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
     });
   });
 
-  it('should accept a node as the input', shouldReportErrors(moveTree, {
+  it('should accept a node as the input', shouldReportErrors(moveNode, {
     options: {
       ignore: false
     }
@@ -248,5 +248,22 @@ describe('EslintValidationFilter', function describeEslintValidationFilter() {
         fs.writeFileSync(eslintrcPath, eslintrcContent);
       }
     });
+  });
+
+  it('throws when `throwOnError` is set and result severity', function() {
+    const promise = shouldReportErrors(FIXTURES, {
+      options: {
+        ignore: false,
+      },
+      throwOnError: true
+    })();
+
+    return promise.then(
+      () => { throw new Error('test should have failed'); },
+      (err) => {
+        expect(err).to.be.an('error');
+        expect(err.message).to.equal('rules violation with `error` severity level');
+      }
+    );
   });
 });


### PR DESCRIPTION
cc @alexlafroscia @Turbo87 

Previously, supporting the `throwOnError` option was broken in `broccoli-lint-eslint` because we weren't passing the right values to the `getResultsSeverity` helper. #44 fixed that, but it was right at the point where we were cutting off different branches and unfortunately it never made it onto the 2.x branch. 

This PR covers the same changes, and should be able to patch 2.6. 