### PR TITLE
add support for throwOnWarn option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,20 +9,25 @@ const escapeStringRegexp = require('escape-string-regexp');
 const BUILD_DIR_REGEXP = new RegExp('(' + escapeStringRegexp(path.sep) + ')?build(' + escapeStringRegexp(path.sep) + ')?$');
 const IGNORED_FILE_MESSAGE_REGEXP = /(?:File ignored by default\.)|(?:File ignored because of a matching ignore pattern\.)/;
 
-
 /**
  * Calculates the severity of a eslint.linter.verify result
- * @param {Array} result Eslint verify result array
- * @returns {Number} If the returned number is greater than 0 the result contains errors.
+ * @param {Array} result ESLint's verify() result array
+ *    @see: http://eslint.org/docs/developer-guide/nodejs-api#linter
+ *
+ * @returns {Number} accumulatedSeverity The total severity from of the list of results
+ *    0 indicates all-clear
+ *    1 indicates a warning-level result
+ *    > 1 indicates an error-level result
  */
 function getResultSeverity(resultMessages = []) {
   return resultMessages.reduce((accumulatedSeverity, message) => {
+    const severity = message.severity || 0;
 
-    if (message.fatal || message.severity === 2) {
-      return accumulatedSeverity + 1;
+    if (message.fatal || severity === 2) {
+      return accumulatedSeverity + 2;
     }
 
-    return accumulatedSeverity;
+    return accumulatedSeverity + severity;
   }, 0);
 }
 
@@ -161,8 +166,8 @@ EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProces
 
 EslintValidationFilter.prototype.processString = function processString(content, relativePath) {
   // verify file content
-  const reportFilePath = path.join(this.eslintrc, relativePath);
-  const report = this.cli.executeOnText(content, reportFilePath);
+  const configPath = path.join(this.eslintrc, relativePath);
+  const report = this.cli.executeOnText(content, configPath);
   const filteredReport = filterAllIgnoredFileMessages(report);
 
   const toCache = { report, output: content };
@@ -200,9 +205,17 @@ EslintValidationFilter.prototype.processString = function processString(content,
      // log formatter output
      this.console.log(this.formatter(report.results));
 
-     if ('throwOnError' in this.internalOptions && this.internalOptions.throwOnError === true) {
-       if (getResultSeverity(report.results[0].messages) > 0) {
-         // throw error if severe messages exist
+     const throwOnWarn = !!this.internalOptions.throwOnWarn;
+     const throwOnError = !!this.internalOptions.throwOnError;
+
+     if (throwOnWarn || throwOnError) {
+       const resultSeverity = getResultSeverity(report.results[0].messages);
+
+       if (resultSeverity === 1 && throwOnWarn) {
+         throw new Error('rules violation with `warn` severity level');
+       }
+
+       if (resultSeverity >= 2 && (throwOnWarn || throwOnError)) {
          throw new Error('rules violation with `error` severity level');
        }
      }

--- a/test/main-tests/fixtures/.eslintignore
+++ b/test/main-tests/fixtures/.eslintignore
@@ -2,6 +2,8 @@
 !alert.js
 !no-new-line-before-return.js
 !unused-variable.js
+!custom-rule-runner.js
+!.eslint-alternate.js
 
 # ignoring a target file
 console.js

--- a/test/main-tests/fixtures/.eslintignore-all-but-warning
+++ b/test/main-tests/fixtures/.eslintignore-all-but-warning
@@ -1,0 +1,8 @@
+# Use this for the `ignorePath` option when we only want to
+# achieve a "warning" level severity
+
+alert.js
+console.js
+custom-rule-runner.js
+unused-variable.js
+.eslintrc-alternate.js

--- a/test/main-tests/fixtures/.eslintrc-alternate.js
+++ b/test/main-tests/fixtures/.eslintrc-alternate.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  extends: 'eslint:recommended',
+  rules: {
+    'no-console': 'off',
+    quotes: ['warn', 'double']
+  }
+};


### PR DESCRIPTION
Closes #45.
 
Mainly, this update is concerned with offering the ability to specify a `throwOnWarn` option, but it has the serendipitous effect of cleaning up or logic for "throwing" in general. `getResultsSeverity` now [computes a more honest value](https://github.com/ember-cli/broccoli-lint-eslint/pull/60/files#diff-6d186b954a58d5bb740f73d84fe39073R32) (instead of adding 1 for severity of 2 :smile:), and the [processString function](https://github.com/ember-cli/broccoli-lint-eslint/pull/60/files#diff-6d186b954a58d5bb740f73d84fe39073R216) can than use this value to make a more informed decision about what it wants to do.

One more thing to note, tough: I also removed the test for using a custom-rule.

We were getting lucky before in that they were being run last, but whenever that wasn’t the case, I’d keep running into the same issue that @nickiaconis [caught a while back](https://github.com/eslint/eslint/issues/5577) with the CLIEngine not necessarily removing the definition on the next test (and thus erring out on a `custom-rule` not being defined). 

Since custom rules are really just one more feature of ESLint itself (and are [well-tested there](https://github.com/eslint/eslint/blob/e13d87e0cc1626c29a73baa11f51d28b04e5741c/tests/fixtures/rules/eslint.json)), I feel like it's one more thing that should be removed from our own tests to make them cleaner.