### PR TITLE
Bust cache if ignored status changes.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -156,11 +156,15 @@ EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProces
     return value;
   }
 
+  var filePath = path.join(this.eslintrc, relativePath);
+  var isIgnoredFile = this.cli.isPathIgnored(filePath);
+
   return md5Hex([
     content,
     relativePath,
+    isIgnoredFile.toString(),
     stringify(this.internalOptions, { replacer: functionStringifier }),
-    stringify(this.cli.getConfigForFile(path.join(this.eslintrc, relativePath)))
+    stringify(this.cli.getConfigForFile(filePath))
   ]);
 };
 


### PR DESCRIPTION
This is to resolve (at least partially?) an upstream issue in ember-cli-eslint. See: https://github.com/ember-cli/ember-cli-eslint/issues/82

The issue was deceiving, because it appeared as if .eslintignore was being completely thrown out the window. However, what I believe people were experiencing was that the build would cache the results of the linting, and then the ignore rules would get added. Since the hash wasn't changing, the old test results were cached and displayed despite the updated ignore rules.

This PR will change it so that if the 'ignored status' of a file changes, linting will be reran. 

I attempted to write a test, but was unable to create the situation. If I ran two consecutive runs in a test, no caching was happening, perhaps due to how the run-eslint test helper is set up? I'm happy to write a test if anyone can think of how to recreate the situation, otherwise I think this is a good change and I tested in a quick ember project.