### PR TITLE
Dont lint ignored files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -156,8 +156,8 @@ EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProces
     return value;
   }
 
-  var filePath = path.join(this.eslintrc, relativePath);
-  var isIgnoredFile = this.cli.isPathIgnored(filePath);
+  const filePath = path.join(this.eslintrc, relativePath);
+  const isIgnoredFile = this.cli.isPathIgnored(filePath);
 
   return md5Hex([
     content,
@@ -167,6 +167,17 @@ EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProces
     stringify(this.cli.getConfigForFile(filePath))
   ]);
 };
+
+EslintValidationFilter.prototype.getDestFilePath = function getDestFilePath(relativePath) {
+  const filterPath = Filter.prototype.getDestFilePath.call(this, relativePath);
+  const fullPath = path.join(this.eslintrc, relativePath);
+
+  if(filterPath && !this.cli.isPathIgnored(fullPath)) {
+    return filterPath;
+  } else {
+    return null
+  }
+}
 
 EslintValidationFilter.prototype.processString = function processString(content, relativePath) {
   // verify file content

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ const stringify = require('json-stable-stringify');
 const path = require('path');
 const escapeStringRegexp = require('escape-string-regexp');
 const BUILD_DIR_REGEXP = new RegExp(`(${escapeStringRegexp(path.sep)})?build(${escapeStringRegexp(path.sep)})?$`);
-const IGNORED_FILE_MESSAGE_REGEXP = /(?:File ignored by default\.)|(?:File ignored because of a matching ignore pattern\.)/;
 
 /**
  * Calculates the severity of a eslint.linter.verify result
@@ -29,32 +28,6 @@ function getResultSeverity(resultMessages = []) {
 
     return accumulatedSeverity + severity;
   }, 0);
-}
-
-/**
- * Ignores messages that are about ignored files as they are intended
- * but we are processing a file at a time
- *
- * @param {Array} errors result errors
- * @returns {Array} filtered errors
- */
-function filterIgnoredFileMessages(errors) {
-  return errors.filter((error) => !IGNORED_FILE_MESSAGE_REGEXP.test(error.message));
-}
-
-/**
- * Filters all ignored file messages from result object
- * @param {Object} result result errors
- * @returns {Object} filtered results
- */
-function filterAllIgnoredFileMessages(result) {
-  const resultOutput = result;
-
-  resultOutput.results.forEach((resultItem) => {
-    resultItem.messages = filterIgnoredFileMessages(resultItem.messages);
-  });
-
-  return resultOutput;
 }
 
 function isString(x) {
@@ -183,12 +156,11 @@ EslintValidationFilter.prototype.processString = function processString(content,
   // verify file content
   const configPath = path.join(this.eslintrc, relativePath);
   const report = this.cli.executeOnText(content, configPath);
-  const filteredReport = filterAllIgnoredFileMessages(report);
 
   const toCache = { report, output: content };
 
-  if (this.testGenerator && Array.isArray(filteredReport.results)) {
-    const result = filteredReport.results[0] || {};
+  if (this.testGenerator && Array.isArray(report.results)) {
+    const result = report.results[0] || {};
     const messages = result.messages || [];
 
     toCache.output = this.testGenerator(relativePath, messages, result);

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,6 +142,8 @@ EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProces
 };
 
 EslintValidationFilter.prototype.getDestFilePath = function getDestFilePath(relativePath) {
+  //This method gets called for all files in the tree, so we call the superclass to filter
+  //based on the extensions property.
   const filterPath = Filter.prototype.getDestFilePath.call(this, relativePath);
   const fullPath = path.join(this.eslintrc, relativePath);
 

--- a/test/main-tests/test.js
+++ b/test/main-tests/test.js
@@ -194,11 +194,9 @@ describe('EslintValidationFilter', function() {
       });
     }
 
-    // Run twice to guarantee one run would be from cache if persisting
     const promise = runNonpersistent();
 
     return promise.then(function() {
-      // check that it did not use the cache
       expect(processStringSpy, 'Doesn\'t call processString for ignored files')
         .to.have.callCount(JS_FIXTURES.length - 1);
     });

--- a/test/main-tests/test.js
+++ b/test/main-tests/test.js
@@ -21,7 +21,7 @@ const FIXTURES_PATH_ESLINTIGNORE_FOR_WARNING = path.resolve(process.cwd(), './te
 const FIXTURES_PATH_ESLINTRC = path.join(FIXTURES_PATH, '.eslintrc.js');
 const FIXTURES_PATH_ESLINTRC_ALTERNATE = path.join(FIXTURES_PATH, '.eslintrc-alternate.js');
 const FIXTURE_FILE_PATH_ALERT = 'fixtures/alert.js';
-const JS_FIXTURES = fs.readdirSync(FIXTURES_PATH).filter((name) => /\.js$/.test(name));
+const JS_FIXTURES = fs.readdirSync(FIXTURES_PATH).filter((name) => /\.js$/.test(name) && !/^.eslintrc/.test(name));
 
 
 describe('EslintValidationFilter', function() {
@@ -178,6 +178,30 @@ describe('EslintValidationFilter', function() {
         expect(postProcessSpy, 'Logged errors')
           .to.have.callCount(JS_FIXTURES.length);
       });
+  });
+
+  it('should not call processString for ignored files', function() {
+    const {
+      processStringSpy
+    } = this.setupSpies();
+
+    function runNonpersistent() {
+      return runEslint(FIXTURES_PATH, {
+        persist: false,
+        options: {
+          ignorePath: FIXTURES_PATH_ESLINTIGNORE
+        }
+      });
+    }
+
+    // Run twice to guarantee one run would be from cache if persisting
+    const promise = runNonpersistent();
+
+    return promise.then(function() {
+      // check that it did not use the cache
+      expect(processStringSpy, 'Doesn\'t call processString for ignored files')
+        .to.have.callCount(JS_FIXTURES.length - 1);
+    });
   });
 
   it('should allow disabling the cache', function() {


### PR DESCRIPTION
This is to remove some confusion around ignored files. Currently, all JS files will show up in the linter as "passed eslint" even if they were ignored. This changes that behavior and if a file is ignored, it never gets run through the linter, and doesn't show up in the test report.