### PR TITLE
Add factory function and "group" option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,9 +6,12 @@ const defaultsDeep = require('lodash.defaultsdeep');
 const md5Hex = require('md5-hex');
 const stringify = require('json-stable-stringify');
 const path = require('path');
+const concat = require('broccoli-concat');
 
 const isString = require('./is-string');
 const getResultSeverity = require('./get-result-severity');
+const testGenerators = require('./test-generators');
+const testGeneratorNames = Object.keys(testGenerators);
 
 function resolveInputDirectory(inputNode) {
   if (typeof inputNode === 'string') {
@@ -68,9 +71,10 @@ function EslintValidationFilter(inputNode, options) {
   this.eslintrc = resolveInputDirectory(inputNode);
 
   if (isString(this.internalOptions.testGenerator)) {
-    const testGenerators = require('./test-generators');
-
     this.testGenerator = testGenerators[this.internalOptions.testGenerator];
+    if (this.internalOptions.group && this.testGenerator) {
+      this.testGenerator = this.testGenerator.testOnly;
+    }
     if (!this.testGenerator) {
       throw new Error(`Could not find '${this.internalOptions.testGenerator}' test generator.`);
     }
@@ -191,5 +195,29 @@ EslintValidationFilter.prototype.postProcess = function postProcess(results /* ,
  * @experimental
  */
 EslintValidationFilter.create = function(inputNode, options) {
-  return new EslintValidationFilter(inputNode, options);
+  options = options || {};
+
+  if (!options.group) {
+    return new EslintValidationFilter(inputNode, options);
+  }
+
+  if (typeof options.testGenerator !== 'string' || testGeneratorNames.indexOf(options.testGenerator) === -1) {
+    throw new Error(`The "group" options can only be used with a "testGenerator" option of: ${testGeneratorNames}`);
+  }
+
+  let testGenerator = testGenerators[options.testGenerator];
+
+  let header = testGenerator.header(options.group);
+  let footer = testGenerator.footer();
+
+  let eslint = new EslintValidationFilter(inputNode, options);
+
+  return concat(eslint, {
+    outputFile: `/${options.group}.lint-test.js`,
+    header,
+    inputFiles: ['**/*.lint-test.js'],
+    footer,
+    sourceMapConfig: { enabled: false },
+    allowNone: true,
+  });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -183,3 +183,13 @@ EslintValidationFilter.prototype.postProcess = function postProcess(results /* ,
 
   return { output: results.output };
 };
+
+/**
+ * Factory function that allows to return something different
+ * instead of a single EslintValidationFilter.
+ *
+ * @experimental
+ */
+EslintValidationFilter.create = function(inputNode, options) {
+  return new EslintValidationFilter(inputNode, options);
+};

--- a/lib/test-generators.js
+++ b/lib/test-generators.js
@@ -17,30 +17,51 @@ function qunit(relativePath, errors, results) {
     `});\n`;
 }
 
+qunit.testOnly = function(relativePath, errors, results) {
+  let passed = hasPassed(results);
+  let message = createAssertionMessage(relativePath, results);
+
+  return `QUnit.test('${escape(relativePath)}', function(assert) {\n` +
+    `  assert.expect(1);\n` +
+    `  assert.ok(${passed}, '${escape(message)}');\n` +
+    `});\n`;
+};
+
 function mocha(relativePath, errors, results) {
   let passed = hasPassed(results);
   let message = createAssertionMessage(relativePath, results);
 
-  let output =
+  return (
     `describe('ESLint | ${escape(relativePath)}', function() {\n` +
-    `  it('should pass ESLint', function() {\n`;
+    `  it('should pass ESLint', function() {\n` +
+    mochaAssertion(passed, message) +
+    `  });\n` +
+    `});\n`
+  );
+}
 
+mocha.testOnly = function(relativePath, errors, results) {
+  let passed = hasPassed(results);
+  let message = createAssertionMessage(relativePath, results);
+
+  return (
+    `  it('${escape(relativePath)}', function() {\n` +
+    mochaAssertion(passed, message) +
+    `  });\n`
+  );
+};
+
+function mochaAssertion(passed, message) {
   if (passed) {
-    output +=
-      `    // ESLint passed\n`;
-  } else {
-    output +=
-      `    // ESLint failed\n` +
-      `    var error = new chai.AssertionError('${escape(message)}');\n` +
-      `    error.stack = undefined;\n` +
-      `    throw error;\n`;
+    return `    // ESLint passed\n`;
   }
 
-  output +=
-    `  });\n` +
-    `});\n`;
-
-  return output;
+  return (
+      `    // ESLint failed\n`+
+      `    var error = new chai.AssertionError('${escape(message)}');\n` +
+      `    error.stack = undefined;\n` +
+      `    throw error;\n`
+  );
 }
 
 function hasPassed(results) {

--- a/lib/test-generators.js
+++ b/lib/test-generators.js
@@ -27,6 +27,14 @@ qunit.testOnly = function(relativePath, errors, results) {
     `});\n`;
 };
 
+qunit.header = function(group) {
+  return `QUnit.module('ESLint | ${escape(group)}');\n`;
+};
+
+qunit.footer = function() {
+  return '';
+};
+
 function mocha(relativePath, errors, results) {
   let passed = hasPassed(results);
   let message = createAssertionMessage(relativePath, results);
@@ -49,6 +57,14 @@ mocha.testOnly = function(relativePath, errors, results) {
     mochaAssertion(passed, message) +
     `  });\n`
   );
+};
+
+mocha.header = function(group) {
+  return `describe('ESLint | ${escape(group)}', function() {\n`;
+};
+
+mocha.footer = function() {
+  return '});\n';
 };
 
 function mochaAssertion(passed, message) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/ember-cli/broccoli-lint-eslint",
   "dependencies": {
+    "broccoli-concat": "^3.2.2",
     "broccoli-persistent-filter": "^1.2.0",
     "eslint": "^3.0.0",
     "js-string-escape": "^1.0.1",

--- a/test/eslint-test.js
+++ b/test/eslint-test.js
@@ -124,7 +124,7 @@ describe('broccoli-lint-eslint', function() {
         'b.js': `var foo = 5;\n`,
       });
 
-      output = createBuilder(eslint(input.path(), { console, testGenerator: 'qunit' }));
+      output = createBuilder(ESLint.create(input.path(), { console, testGenerator: 'qunit' }));
 
       yield output.build();
 
@@ -146,7 +146,7 @@ describe('broccoli-lint-eslint', function() {
         'b.js': `var foo = 5;\n`,
       });
 
-      output = createBuilder(eslint(input.path(), { console, testGenerator: 'mocha' }));
+      output = createBuilder(ESLint.create(input.path(), { console, testGenerator: 'mocha' }));
 
       yield output.build();
 
@@ -176,7 +176,7 @@ describe('broccoli-lint-eslint', function() {
         args.push(arguments);
       }
 
-      output = createBuilder(eslint(input.path(), { console, testGenerator }));
+      output = createBuilder(ESLint.create(input.path(), { console, testGenerator }));
 
       yield output.build();
 
@@ -215,7 +215,7 @@ describe('broccoli-lint-eslint', function() {
         'a.js': `console.log('foo');\n`,
       });
 
-      output = createBuilder(eslint(input.path(), { console, throwOnError: true }));
+      output = createBuilder(ESLint.create(input.path(), { console, throwOnError: true }));
 
       yield expect(output.build()).to.be.rejectedWith('rules violation with `error` severity level');
     }));
@@ -226,7 +226,7 @@ describe('broccoli-lint-eslint', function() {
         'a.js': `console.log('foo');\n`,
       });
 
-      output = createBuilder(eslint(input.path(), { console, throwOnError: true }));
+      output = createBuilder(ESLint.create(input.path(), { console, throwOnError: true }));
 
       yield expect(output.build()).to.be.fulfilled;
     }));
@@ -237,7 +237,7 @@ describe('broccoli-lint-eslint', function() {
         'a.js': `console.log('foo');\n`,
       });
 
-      output = createBuilder(eslint(input.path(), { console, throwOnError: true }));
+      output = createBuilder(ESLint.create(input.path(), { console, throwOnError: true }));
 
       yield expect(output.build()).to.be.fulfilled;
     }));
@@ -250,7 +250,7 @@ describe('broccoli-lint-eslint', function() {
         'a.js': `console.log('foo');\n`,
       });
 
-      output = createBuilder(eslint(input.path(), { console, throwOnWarn: true }));
+      output = createBuilder(ESLint.create(input.path(), { console, throwOnWarn: true }));
 
       yield expect(output.build()).to.be.rejectedWith('rules violation with `error` severity level');
     }));
@@ -261,7 +261,7 @@ describe('broccoli-lint-eslint', function() {
         'a.js': `console.log('foo');\n`,
       });
 
-      output = createBuilder(eslint(input.path(), { console, throwOnWarn: true }));
+      output = createBuilder(ESLint.create(input.path(), { console, throwOnWarn: true }));
 
       yield expect(output.build()).to.be.rejectedWith('rules violation with `warn` severity level');
     }));
@@ -272,7 +272,7 @@ describe('broccoli-lint-eslint', function() {
         'a.js': `console.log('foo');\n`,
       });
 
-      output = createBuilder(eslint(input.path(), { console, throwOnWarn: true }));
+      output = createBuilder(ESLint.create(input.path(), { console, throwOnWarn: true }));
 
       yield expect(output.build()).to.be.fulfilled;
     }));
@@ -288,7 +288,7 @@ describe('broccoli-lint-eslint', function() {
         'b.js': `var foo = 5;\n`,
       });
 
-      output = createBuilder(eslint(input.path(), { console, testGenerator: 'qunit' }));
+      output = createBuilder(ESLint.create(input.path(), { console, testGenerator: 'qunit' }));
 
       yield output.build();
 

--- a/test/eslint-test.js
+++ b/test/eslint-test.js
@@ -77,6 +77,31 @@ describe('broccoli-lint-eslint', function() {
       .to.contain(`b.js: line 1, col 5, Warning - 'foo' is assigned a value but never used. (no-unused-vars)\n`);
   }));
 
+  it('logs errors to the console (using create() factory method)', co.wrap(function *() {
+    input.write({
+      '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
+      'a.js': `console.log('foo');\n`,
+      'b.js': `var foo = 5;\n`,
+    });
+
+    let format = 'eslint/lib/formatters/compact';
+
+    let messages = [];
+    let console = {
+      log(message) {
+        messages.push(message);
+      }
+    };
+
+    output = createBuilder(ESLint.create(input.path(), { format, console }));
+
+    yield output.build();
+
+    expect(messages.join(''))
+      .to.contain(`a.js: line 1, col 1, Error - Unexpected console statement. (no-console)\n`)
+      .to.contain(`b.js: line 1, col 5, Warning - 'foo' is assigned a value but never used. (no-unused-vars)\n`);
+  }));
+
   it('does not generate test files by default', co.wrap(function *() {
     input.write({
       '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,

--- a/test/helpers/run-eslint.js
+++ b/test/helpers/run-eslint.js
@@ -15,7 +15,7 @@ module.exports = function runEslint(path, _options) {
   };
   options.options = options.options || {};
 
-  const node = eslintValidationFilter(path, options);
+  const node = eslintValidationFilter.create(path, options);
   const builder = new broccoli.Builder(node);
   const promise = builder.build().then(() => ({
     buildLog: buildLog.join('\n'),

--- a/test/test-generators-test.js
+++ b/test/test-generators-test.js
@@ -57,6 +57,40 @@ QUnit.test('should pass ESLint', function(assert) {
   assert.ok(false, 'some/file.js should pass ESLint\\n\\n42:13 - This is not a valid foo (validate-foo)\\n123:1 - foobar (comma-dangle)');
 });`.trim());
     });
+
+    describe('testOnly', function() {
+      it('generates passing test for missing errorCount', function() {
+        expect(this.generate.testOnly('some/file.js', null, {}).trim()).to.equal(`
+QUnit.test('some/file.js', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'some/file.js should pass ESLint');
+});`.trim());
+      });
+
+      it('generates passing test for errorCount == 0', function() {
+        expect(this.generate.testOnly('some/file.js', null, { errorCount: 0 }).trim()).to.equal(`
+QUnit.test('some/file.js', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'some/file.js should pass ESLint');
+});`.trim());
+      });
+
+      it('generates passing test for errorCount == 1', function() {
+        expect(this.generate.testOnly('some/file.js', null, { errorCount: 1 }).trim()).to.equal(`
+QUnit.test('some/file.js', function(assert) {
+  assert.expect(1);
+  assert.ok(false, 'some/file.js should pass ESLint');
+});`.trim());
+      });
+
+      it('renders error messages', function() {
+        expect(this.generate.testOnly('some/file.js', null, FAIL).trim()).to.equal(`
+QUnit.test('some/file.js', function(assert) {
+  assert.expect(1);
+  assert.ok(false, 'some/file.js should pass ESLint\\n\\n42:13 - This is not a valid foo (validate-foo)\\n123:1 - foobar (comma-dangle)');
+});`.trim());
+      });
+    });
   });
 
   describe('mocha', function() {
@@ -104,6 +138,42 @@ describe('ESLint | some/file.js', function() {
     throw error;
   });
 });`.trim());
+    });
+
+    describe('testOnly', function() {
+      it('generates passing test for missing errorCount', function() {
+        expect(this.generate.testOnly('some/file.js', null, {}).trim()).to.equal(`
+  it('some/file.js', function() {
+    // ESLint passed
+  });`.trim());
+      });
+
+      it('generates passing test for errorCount == 0', function() {
+        expect(this.generate.testOnly('some/file.js', null, { errorCount: 0 }).trim()).to.equal(`
+  it('some/file.js', function() {
+    // ESLint passed
+  });`.trim());
+      });
+
+      it('generates passing test for errorCount == 1', function() {
+        expect(this.generate.testOnly('some/file.js', null, { errorCount: 1 }).trim()).to.equal(`
+  it('some/file.js', function() {
+    // ESLint failed
+    var error = new chai.AssertionError('some/file.js should pass ESLint');
+    error.stack = undefined;
+    throw error;
+  });`.trim());
+      });
+
+      it('renders error messages', function() {
+        expect(this.generate.testOnly('some/file.js', null, FAIL).trim()).to.equal(`
+  it('some/file.js', function() {
+    // ESLint failed
+    var error = new chai.AssertionError('some/file.js should pass ESLint\\n\\n42:13 - This is not a valid foo (validate-foo)\\n123:1 - foobar (comma-dangle)');
+    error.stack = undefined;
+    throw error;
+  });`.trim());
+      });
     });
   });
 });


### PR DESCRIPTION
This PR adds a `create()` factory function to the `EslintValidationFilter` class, which allows us to return something other than just a `EslintValidationFilter` instance.

The PR also adds a `group` option which (in combination with a `testGenerator` option of `qunit` or `mocha`) can be used to generate all tests into a single file and test module:

```js
QUnit.module('ESLint | app');

QUnit.test('a.js', function(assert) {
  assert.expect(1);
  assert.ok(false, 'a.js should pass ESLint\n\n1:1 - Unexpected console statement. (no-console)');
});

QUnit.test('b.js', function(assert) {
  assert.expect(1);
  assert.ok(true, 'b.js should pass ESLint');
});
```

All this should be implemented in a backwards compatible way so that we can release it in a minor version bump.

Closes #92 

see also https://github.com/ember-cli/ember-cli-eslint/pull/176