### PR TITLE
Cleaning up unused options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ var outputNode = ESLint.create(inputNode, options);
 
     return eslint(inputNode, {
       options: {
-        configFile: this.eslintrc.app + '/eslint.json',
-        rulesdir: this.eslintrc.app
+        configFile: this.eslintrc.app + '/eslint.json'
       },
       testGenerator: testGenerator
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function resolveInputDirectory(inputNode) {
 /**
  * Uses the content of each file in a given node and runs eslint validation on it.
  * @param {Object} inputNode Node from broccoli.makeTree
- * @param {{config: String, rulesdir: String, format: String}} options Filter options
+ * @param {{format: String, options: EslintOptions}} options Filter options
  * @returns {EslintValidationFilter} Filter obconfig @constructor
  */
 function EslintValidationFilter(inputNode, options) {


### PR DESCRIPTION
Have noticed that `rulesdir` is not used within the code, and if I'm not mistaken was documented incorrectly (should probably be passed into eslint options).

