### PR TITLE
Accept multiple input nodes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,8 +49,10 @@ function EslintValidationFilter(inputNode, options) {
   let _console = options.console || console;
 
   if (!options[FACTORY_METHOD_USED]) {
-    _console.log('[broccoli-lint-eslint] DEPRECATION: Please use the create() factory method instead of ' +
-      'calling ESLint() directly or using new ESLint()');
+    _console.log(
+      '[broccoli-lint-eslint] DEPRECATION: Please use the create() factory method instead of ' +
+        'calling ESLint() directly or using new ESLint()'
+    );
   }
 
   options = defaultsDeep({}, options, {
@@ -73,7 +75,8 @@ function EslintValidationFilter(inputNode, options) {
     this.formatter = this.internalOptions.format;
   } else {
     // eslint-disable-next-line global-require
-    this.formatter = require(this.internalOptions.format || 'eslint/lib/formatters/stylish');
+    this.formatter = require(this.internalOptions.format ||
+      'eslint/lib/formatters/stylish');
   }
 
   this.console = _console;
@@ -88,7 +91,9 @@ function EslintValidationFilter(inputNode, options) {
       this.testGenerator = this.testGenerator.testOnly;
     }
     if (!this.testGenerator) {
-      throw new Error(`Could not find '${this.internalOptions.testGenerator}' test generator.`);
+      throw new Error(
+        `Could not find '${this.internalOptions.testGenerator}' test generator.`
+      );
     }
   } else {
     this.testGenerator = this.internalOptions.testGenerator;
@@ -108,7 +113,10 @@ EslintValidationFilter.prototype.baseDir = function baseDir() {
   return path.join(__dirname, '..');
 };
 
-EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProcessString(content, relativePath) {
+EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProcessString(
+  content,
+  relativePath
+) {
   function functionStringifier(key, value) {
     if (typeof value === 'function') {
       return value.toString();
@@ -124,11 +132,13 @@ EslintValidationFilter.prototype.cacheKeyProcessString = function cacheKeyProces
     relativePath,
     isIgnoredFile.toString(),
     stringify(this.internalOptions, { replacer: functionStringifier }),
-    stringify(this.cli.getConfigForFile(filePath))
+    stringify(this.cli.getConfigForFile(filePath)),
   ]);
 };
 
-EslintValidationFilter.prototype.getDestFilePath = function getDestFilePath(relativePath) {
+EslintValidationFilter.prototype.getDestFilePath = function getDestFilePath(
+  relativePath
+) {
   //This method gets called for all files in the tree, so we call the superclass to filter
   //based on the extensions property.
   const filterPath = Filter.prototype.getDestFilePath.apply(this, arguments);
@@ -141,7 +151,10 @@ EslintValidationFilter.prototype.getDestFilePath = function getDestFilePath(rela
   }
 };
 
-EslintValidationFilter.prototype.processString = function processString(content, relativePath) {
+EslintValidationFilter.prototype.processString = function processString(
+  content,
+  relativePath
+) {
   // verify file content
   const configPath = path.join(this.eslintrc, relativePath);
   const report = this.cli.executeOnText(content, configPath);
@@ -170,13 +183,13 @@ EslintValidationFilter.prototype.processString = function processString(content,
  * @returns {Object} An object with an `.output` property, which will be
  *    used as the emitted file contents
  */
-EslintValidationFilter.prototype.postProcess = function postProcess(results /* , relativePath */) {
+EslintValidationFilter.prototype.postProcess = function postProcess(
+  results /* , relativePath */
+) {
   let report = results.report;
 
   // if verification has result
-  if (report.results.length &&
-      report.results[0].messages.length) {
-
+  if (report.results.length && report.results[0].messages.length) {
     // log formatter output
     this.console.log(this.formatter(report.results));
 
@@ -207,15 +220,22 @@ EslintValidationFilter.prototype.postProcess = function postProcess(results /* ,
  */
 EslintValidationFilter.create = function(inputNode, _options) {
   let options = Object.assign({}, _options, {
-    [FACTORY_METHOD_USED]: true
+    [FACTORY_METHOD_USED]: true,
   });
 
   if (!options.group) {
     return new EslintValidationFilter(inputNode, options);
   }
 
-  if (typeof options.testGenerator !== 'string' || testGeneratorNames.indexOf(options.testGenerator) === -1) {
-    throw new Error(`The "group" options can only be used with a "testGenerator" option of: ${testGeneratorNames}`);
+  if (
+    typeof options.testGenerator !== 'string' ||
+    testGeneratorNames.indexOf(options.testGenerator) === -1
+  ) {
+    throw new Error(
+      `The "group" options can only be used with a "testGenerator" option of: ${
+        testGeneratorNames
+      }`
+    );
   }
 
   let testGenerator = testGenerators[options.testGenerator];
@@ -238,5 +258,5 @@ EslintValidationFilter.create = function(inputNode, _options) {
 Object.defineProperty(EslintValidationFilter, 'testGenerators', {
   get() {
     return testGeneratorNames.slice(0);
-  }
+  },
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,10 +12,11 @@ const isString = require('./is-string');
 const getResultSeverity = require('./get-result-severity');
 const testGenerators = require('./test-generators');
 const testGeneratorNames = Object.keys(testGenerators);
+const nodeIncludesOverrides = require('./node-includes-overrides');
 
 const FACTORY_METHOD_USED = Symbol('create() factory method was used');
 
-function resolveInputDirectory(inputNode) {
+function resolveInputDirectory(inputNode, eslintIncludesOverrides) {
   if (typeof inputNode === 'string') {
     return inputNode;
   }
@@ -27,12 +28,14 @@ function resolveInputDirectory(inputNode) {
     return nodeInfo.sourceDirectory;
   }
 
-  if (nodeInfo.inputNodes.length > 1) {
+  if (nodeInfo.inputNodes.length > 1 && !eslintIncludesOverrides) {
     // eslint-disable-next-line max-len
-    throw new Error('EslintValidationFilter can only handle one:* broccoli nodes, but part of the given input pipeline is a many:* node. (broccoli-merge-trees is an example of a many:* node) Please perform many:* operations after linting.');
+    throw new Error(
+      'EslintValidationFilter can only handle one:* broccoli nodes, but part of the given input pipeline is a many:* node. (broccoli-merge-trees is an example of a many:* node) Please perform many:* operations after linting.'
+    );
   }
 
-  return resolveInputDirectory(nodeInfo.inputNodes[0]);
+  return resolveInputDirectory(nodeInfo.inputNodes[0], eslintIncludesOverrides);
 }
 
 /**
@@ -83,7 +86,10 @@ function EslintValidationFilter(inputNode, options) {
 
   this.cli = new CLIEngine(options.options);
 
-  this.eslintrc = resolveInputDirectory(inputNode);
+  this.eslintrc = resolveInputDirectory(
+    inputNode,
+    nodeIncludesOverrides(inputNode, this.cli)
+  );
 
   if (isString(this.internalOptions.testGenerator)) {
     this.testGenerator = testGenerators[this.internalOptions.testGenerator];

--- a/lib/node-includes-overrides.js
+++ b/lib/node-includes-overrides.js
@@ -1,0 +1,34 @@
+/**
+ * Uses eslint (private) api to see if eslint config includes a `overrides` flag.
+ *
+ * inputNode type is a bit tricky here. We are expecting three different cases:
+ * if it's string, we will use it as a directory and let eslint do the work.
+ *
+ * if it's a source node, use the `sourceDirectory` property.
+ *
+ * if it's a transform node, recursively call same function with all of its
+ * inputNodes. if any of the input directories contain `overrides` eslint
+ * config, return true
+ *
+ * While it's not ideal we iterate through all the `inputNodes` of a transform node,
+ * the input size should be very small.
+ */
+const nodeIncludesOverrides = (inputNode, eslintCli) => {
+  if (typeof inputNode === 'string') {
+    return eslintCli.config
+      .getConfigHierarchy(inputNode)
+      .some(node => node.overrides);
+  }
+
+  const { nodeType, sourceDirectory } = inputNode.__broccoliGetInfo__();
+  if (nodeType === 'transform') {
+    const nodesIncludesOverrides = inputNode._inputNodes.map(node =>
+      nodeIncludesOverrides(node, eslintCli)
+    );
+    return nodesIncludesOverrides.some(Boolean);
+  }
+
+  return nodeIncludesOverrides(sourceDirectory, eslintCli);
+};
+
+module.exports = nodeIncludesOverrides;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "4.2.1",
   "description": "broccoli filter that runs eslint",
   "main": "lib/index.js",
+  "engines": {
+    "node": ">=4"
+  },
   "scripts": {
     "lint": "eslint .",
     "test": "mocha test/*test.js test/**/*test.js"

--- a/test/eslint-test.js
+++ b/test/eslint-test.js
@@ -13,19 +13,23 @@ const createTempDir = testHelpers.createTempDir;
 describe('broccoli-lint-eslint', function() {
   let input, output, console;
 
-  beforeEach(co.wrap(function *() {
-    input = yield createTempDir();
-    console = {
-      log(line) {},
-    };
-  }));
+  beforeEach(
+    co.wrap(function*() {
+      input = yield createTempDir();
+      console = {
+        log(line) {},
+      };
+    })
+  );
 
-  afterEach(co.wrap(function *() {
-    yield input.dispose();
-    if (output) {
-      yield output.dispose();
-    }
-  }));
+  afterEach(
+    co.wrap(function*() {
+      yield input.dispose();
+      if (output) {
+        yield output.dispose();
+      }
+    })
+  );
 
   it('exports a static immutable "testGenerators" list', function() {
     expect(eslint.testGenerators).to.deep.equal(['qunit', 'mocha']);
@@ -35,416 +39,556 @@ describe('broccoli-lint-eslint', function() {
     expect(eslint.testGenerators).to.deep.equal(['qunit', 'mocha']);
   });
 
-  it('logs errors to the console (using factory function)', co.wrap(function *() {
-    input.write({
-      '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-      'a.js': `console.log('foo');\n`,
-      'b.js': `var foo = 5;\n`,
-    });
+  it(
+    'logs errors to the console (using factory function)',
+    co.wrap(function*() {
+      input.write({
+        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
+        'a.js': `console.log('foo');\n`,
+        'b.js': `var foo = 5;\n`,
+      });
 
-    let format = 'eslint/lib/formatters/compact';
+      let format = 'eslint/lib/formatters/compact';
 
-    let messages = [];
-    let console = {
-      log(message) {
-        messages.push(message);
-      }
-    };
+      let messages = [];
+      let console = {
+        log(message) {
+          messages.push(message);
+        },
+      };
 
-    output = createBuilder(eslint(input.path(), { format, console }));
+      output = createBuilder(eslint(input.path(), { format, console }));
 
-    yield output.build();
+      yield output.build();
 
-    expect(messages.join(''))
-      .to.contain(`a.js: line 1, col 1, Error - Unexpected console statement. (no-console)\n`)
-      .to.contain(`b.js: line 1, col 5, Warning - 'foo' is assigned a value but never used. (no-unused-vars)\n`)
-      .to.contain(`DEPRECATION: Please use the create() factory method`);
-  }));
+      expect(messages.join(''))
+        .to.contain(
+          `a.js: line 1, col 1, Error - Unexpected console statement. (no-console)\n`
+        )
+        .to.contain(
+          `b.js: line 1, col 5, Warning - 'foo' is assigned a value but never used. (no-unused-vars)\n`
+        )
+        .to.contain(`DEPRECATION: Please use the create() factory method`);
+    })
+  );
 
-  it('logs errors to the console (using new)', co.wrap(function *() {
-    input.write({
-      '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-      'a.js': `console.log('foo');\n`,
-      'b.js': `var foo = 5;\n`,
-    });
+  it(
+    'logs errors to the console (using new)',
+    co.wrap(function*() {
+      input.write({
+        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
+        'a.js': `console.log('foo');\n`,
+        'b.js': `var foo = 5;\n`,
+      });
 
-    let format = 'eslint/lib/formatters/compact';
+      let format = 'eslint/lib/formatters/compact';
 
-    let messages = [];
-    let console = {
-      log(message) {
-        messages.push(message);
-      }
-    };
+      let messages = [];
+      let console = {
+        log(message) {
+          messages.push(message);
+        },
+      };
 
-    output = createBuilder(new ESLint(input.path(), { format, console }));
+      output = createBuilder(new ESLint(input.path(), { format, console }));
 
-    yield output.build();
+      yield output.build();
 
-    expect(messages.join(''))
-      .to.contain(`a.js: line 1, col 1, Error - Unexpected console statement. (no-console)\n`)
-      .to.contain(`b.js: line 1, col 5, Warning - 'foo' is assigned a value but never used. (no-unused-vars)\n`)
-      .to.contain(`DEPRECATION: Please use the create() factory method`);
-  }));
+      expect(messages.join(''))
+        .to.contain(
+          `a.js: line 1, col 1, Error - Unexpected console statement. (no-console)\n`
+        )
+        .to.contain(
+          `b.js: line 1, col 5, Warning - 'foo' is assigned a value but never used. (no-unused-vars)\n`
+        )
+        .to.contain(`DEPRECATION: Please use the create() factory method`);
+    })
+  );
 
-  it('logs errors to the console (using create() factory method)', co.wrap(function *() {
-    input.write({
-      '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-      'a.js': `console.log('foo');\n`,
-      'b.js': `var foo = 5;\n`,
-    });
+  it(
+    'logs errors to the console (using create() factory method)',
+    co.wrap(function*() {
+      input.write({
+        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
+        'a.js': `console.log('foo');\n`,
+        'b.js': `var foo = 5;\n`,
+      });
 
-    let format = 'eslint/lib/formatters/compact';
+      let format = 'eslint/lib/formatters/compact';
 
-    let messages = [];
-    let console = {
-      log(message) {
-        messages.push(message);
-      }
-    };
+      let messages = [];
+      let console = {
+        log(message) {
+          messages.push(message);
+        },
+      };
 
-    output = createBuilder(ESLint.create(input.path(), { format, console }));
+      output = createBuilder(ESLint.create(input.path(), { format, console }));
 
-    yield output.build();
+      yield output.build();
 
-    expect(messages.join(''))
-      .to.contain(`a.js: line 1, col 1, Error - Unexpected console statement. (no-console)\n`)
-      .to.contain(`b.js: line 1, col 5, Warning - 'foo' is assigned a value but never used. (no-unused-vars)\n`)
-      .to.not.contain(`DEPRECATION: Please use the create() factory method`);
-  }));
+      expect(messages.join(''))
+        .to.contain(
+          `a.js: line 1, col 1, Error - Unexpected console statement. (no-console)\n`
+        )
+        .to.contain(
+          `b.js: line 1, col 5, Warning - 'foo' is assigned a value but never used. (no-unused-vars)\n`
+        )
+        .to.not.contain(`DEPRECATION: Please use the create() factory method`);
+    })
+  );
 
-  it('does not generate test files by default', co.wrap(function *() {
-    input.write({
-      '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-      'a.js': `console.log('foo');\n`,
-      'b.js': `var foo = 5;\n`,
-    });
+  it(
+    'does not generate test files by default',
+    co.wrap(function*() {
+      input.write({
+        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
+        'a.js': `console.log('foo');\n`,
+        'b.js': `var foo = 5;\n`,
+      });
 
-    output = createBuilder(eslint(input.path(), { console }));
+      output = createBuilder(eslint(input.path(), { console }));
 
-    yield output.build();
+      yield output.build();
 
-    expect(Object.keys(output.read())).to.deep.equal(['.eslintrc.js', 'a.js', 'b.js']);
-  }));
+      expect(Object.keys(output.read())).to.deep.equal([
+        '.eslintrc.js',
+        'a.js',
+        'b.js',
+      ]);
+    })
+  );
 
-  it('should lint typescript files if ts extension is added', co.wrap(function *() {
-    input.write({
-      '.eslintrc.js': `module.exports = { rules: { 'no-unused-vars': 'error' } };\n`,
-      'a.ts': `var foo = 5;\n`
-    });
-    let format = 'eslint/lib/formatters/compact';
+  it(
+    'should lint typescript files if ts extension is added',
+    co.wrap(function*() {
+      input.write({
+        '.eslintrc.js': `module.exports = { rules: { 'no-unused-vars': 'error' } };\n`,
+        'a.ts': `var foo = 5;\n`,
+      });
+      let format = 'eslint/lib/formatters/compact';
 
-    let messages = [];
-    let console = {
-      log(message) {
-        messages.push(message);
-      }
-    };
+      let messages = [];
+      let console = {
+        log(message) {
+          messages.push(message);
+        },
+      };
 
-    output = createBuilder(eslint(input.path(), { format, console, extensions: ['ts'] }));
+      output = createBuilder(
+        eslint(input.path(), { format, console, extensions: ['ts'] })
+      );
 
-    yield output.build();
+      yield output.build();
 
-    expect(messages.join('\n')).to.contain(`a.ts: line 1, col 5, Error - 'foo' is assigned a value but never used. (no-unused-vars)\n`);
-  }));
+      expect(messages.join('\n')).to.contain(
+        `a.ts: line 1, col 5, Error - 'foo' is assigned a value but never used. (no-unused-vars)\n`
+      );
+    })
+  );
 
   describe('testGenerator', function() {
-    it('qunit: generates QUnit tests', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-        'a.js': `console.log('foo');\n`,
-        'b.js': `var foo = 5;\n`,
-      });
+    it(
+      'qunit: generates QUnit tests',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
+          'a.js': `console.log('foo');\n`,
+          'b.js': `var foo = 5;\n`,
+        });
 
-      output = createBuilder(ESLint.create(input.path(), { console, testGenerator: 'qunit' }));
+        output = createBuilder(
+          ESLint.create(input.path(), { console, testGenerator: 'qunit' })
+        );
 
-      yield output.build();
+        yield output.build();
 
-      let result = output.read();
-      expect(Object.keys(result)).to.deep.equal(['.eslintrc.lint-test.js', 'a.lint-test.js', 'b.lint-test.js']);
-      expect(result['a.lint-test.js'].trim()).to.equal([
-        `QUnit.module('ESLint | a.js');`,
-        `QUnit.test('should pass ESLint', function(assert) {`,
-        `  assert.expect(1);`,
-        `  assert.ok(false, 'a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
-        `});`,
-      ].join('\n'));
-    }));
+        let result = output.read();
+        expect(Object.keys(result)).to.deep.equal([
+          '.eslintrc.lint-test.js',
+          'a.lint-test.js',
+          'b.lint-test.js',
+        ]);
+        expect(result['a.lint-test.js'].trim()).to.equal(
+          [
+            `QUnit.module('ESLint | a.js');`,
+            `QUnit.test('should pass ESLint', function(assert) {`,
+            `  assert.expect(1);`,
+            `  assert.ok(false, 'a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
+            `});`,
+          ].join('\n')
+        );
+      })
+    );
 
-    it('mocha: generates Mocha tests', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-        'a.js': `console.log('foo');\n`,
-        'b.js': `var foo = 5;\n`,
-      });
+    it(
+      'mocha: generates Mocha tests',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
+          'a.js': `console.log('foo');\n`,
+          'b.js': `var foo = 5;\n`,
+        });
 
-      output = createBuilder(ESLint.create(input.path(), { console, testGenerator: 'mocha' }));
+        output = createBuilder(
+          ESLint.create(input.path(), { console, testGenerator: 'mocha' })
+        );
 
-      yield output.build();
+        yield output.build();
 
-      let result = output.read();
-      expect(Object.keys(result)).to.deep.equal(['.eslintrc.lint-test.js', 'a.lint-test.js', 'b.lint-test.js']);
-      expect(result['a.lint-test.js'].trim()).to.equal([
-        `describe('ESLint | a.js', function() {`,
-        `  it('should pass ESLint', function() {`,
-        `    // test failed`,
-        `    var error = new chai.AssertionError('a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
-        `    error.stack = undefined;`,
-        `    throw error;`,
-        `  });`,
-        `});`,
-      ].join('\n'));
-    }));
+        let result = output.read();
+        expect(Object.keys(result)).to.deep.equal([
+          '.eslintrc.lint-test.js',
+          'a.lint-test.js',
+          'b.lint-test.js',
+        ]);
+        expect(result['a.lint-test.js'].trim()).to.equal(
+          [
+            `describe('ESLint | a.js', function() {`,
+            `  it('should pass ESLint', function() {`,
+            `    // test failed`,
+            `    var error = new chai.AssertionError('a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
+            `    error.stack = undefined;`,
+            `    throw error;`,
+            `  });`,
+            `});`,
+          ].join('\n')
+        );
+      })
+    );
 
-    it('custom: generates tests via custom test generator function', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-        'a.js': `console.log('foo');\n`,
-        'b.js': `var foo = 5;\n`,
-      });
+    it(
+      'custom: generates tests via custom test generator function',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
+          'a.js': `console.log('foo');\n`,
+          'b.js': `var foo = 5;\n`,
+        });
 
-      let args = [];
-      function testGenerator() {
-        args.push(arguments);
-      }
+        let args = [];
+        function testGenerator() {
+          args.push(arguments);
+        }
 
-      output = createBuilder(ESLint.create(input.path(), { console, testGenerator }));
+        output = createBuilder(
+          ESLint.create(input.path(), { console, testGenerator })
+        );
 
-      yield output.build();
+        yield output.build();
 
-      expect(args).to.have.lengthOf(3);
-      expect(args[0][0]).to.equal('.eslintrc.js');
-      expect(args[1][0]).to.equal('a.js');
-      expect(args[2][0]).to.equal('b.js');
+        expect(args).to.have.lengthOf(3);
+        expect(args[0][0]).to.equal('.eslintrc.js');
+        expect(args[1][0]).to.equal('a.js');
+        expect(args[2][0]).to.equal('b.js');
 
-      let results = args[1][2];
-      expect(results.filePath).to.match(/a\.js$/);
-      delete results.filePath;
+        let results = args[1][2];
+        expect(results.filePath).to.match(/a\.js$/);
+        delete results.filePath;
 
-      expect(results).to.deep.equal({
-        'errorCount': 1,
-        'fixableErrorCount': 0,
-        'fixableWarningCount': 0,
-        'messages': [{
-          'column': 1,
-          'endColumn': 12,
-          'endLine': 1,
-          'line': 1,
-          'message': 'Unexpected console statement.',
-          'nodeType': 'MemberExpression',
-          'ruleId': 'no-console',
-          'severity': 2,
-          'source': 'console.log(\'foo\');',
-        }],
-        'source': 'console.log(\'foo\');\n',
-        'warningCount': 0,
-      });
-    }));
+        expect(results).to.deep.equal({
+          errorCount: 1,
+          fixableErrorCount: 0,
+          fixableWarningCount: 0,
+          messages: [
+            {
+              column: 1,
+              endColumn: 12,
+              endLine: 1,
+              line: 1,
+              message: 'Unexpected console statement.',
+              nodeType: 'MemberExpression',
+              ruleId: 'no-console',
+              severity: 2,
+              source: "console.log('foo');",
+            },
+          ],
+          source: "console.log('foo');\n",
+          warningCount: 0,
+        });
+      })
+    );
   });
 
   describe('group', function() {
-    it('qunit: generates a single QUnit module', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-        'a.js': `console.log('foo');\n`,
-        'b.js': `var foo = 5;\n`,
-      });
-
-      output = createBuilder(eslint.create(input.path(), { console, testGenerator: 'qunit', group: 'app' }));
-
-      yield output.build();
-
-      let result = output.read();
-      expect(Object.keys(result)).to.deep.equal(['app.lint-test.js']);
-      expect(result['app.lint-test.js'].trim()).to.equal([
-        `QUnit.module('ESLint | app');`,
-        ``,
-        `QUnit.test('a.js', function(assert) {`,
-        `  assert.expect(1);`,
-        `  assert.ok(false, 'a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
-        `});`,
-        ``,
-        `QUnit.test('b.js', function(assert) {`,
-        `  assert.expect(1);`,
-        `  assert.ok(true, 'b.js should pass ESLint\\n\\n1:5 - \\'foo\\' is assigned a value but never used. (no-unused-vars)');`,
-        `});`,
-      ].join('\n'));
-    }));
-
-    it('grouping tolerates removal of files (GH: ember-cli/ember-cli#7347)', co.wrap(function *() {
-      let result;
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-        'foo': {
+    it(
+      'qunit: generates a single QUnit module',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
           'a.js': `console.log('foo');\n`,
           'b.js': `var foo = 5;\n`,
-        }
-      });
+        });
 
-      output = createBuilder(eslint.create(input.path(), { console, testGenerator: 'qunit', group: 'app' }));
+        output = createBuilder(
+          eslint.create(input.path(), {
+            console,
+            testGenerator: 'qunit',
+            group: 'app',
+          })
+        );
 
-      yield output.build();
+        yield output.build();
 
-      result = output.read();
-      expect(Object.keys(result)).to.deep.equal(['app.lint-test.js']);
-      expect(result['app.lint-test.js'].trim()).to.equal([
-        `QUnit.module('ESLint | app');`,
-        ``,
-        `QUnit.test('foo/a.js', function(assert) {`,
-        `  assert.expect(1);`,
-        `  assert.ok(false, 'foo/a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
-        `});`,
-        ``,
-        `QUnit.test('foo/b.js', function(assert) {`,
-        `  assert.expect(1);`,
-        `  assert.ok(true, 'foo/b.js should pass ESLint\\n\\n1:5 - \\'foo\\' is assigned a value but never used. (no-unused-vars)');`,
-        `});`,
-      ].join('\n'));
+        let result = output.read();
+        expect(Object.keys(result)).to.deep.equal(['app.lint-test.js']);
+        expect(result['app.lint-test.js'].trim()).to.equal(
+          [
+            `QUnit.module('ESLint | app');`,
+            ``,
+            `QUnit.test('a.js', function(assert) {`,
+            `  assert.expect(1);`,
+            `  assert.ok(false, 'a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
+            `});`,
+            ``,
+            `QUnit.test('b.js', function(assert) {`,
+            `  assert.expect(1);`,
+            `  assert.ok(true, 'b.js should pass ESLint\\n\\n1:5 - \\'foo\\' is assigned a value but never used. (no-unused-vars)');`,
+            `});`,
+          ].join('\n')
+        );
+      })
+    );
 
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-        foo: {
+    it(
+      'grouping tolerates removal of files (GH: ember-cli/ember-cli#7347)',
+      co.wrap(function*() {
+        let result;
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
+          foo: {
+            'a.js': `console.log('foo');\n`,
+            'b.js': `var foo = 5;\n`,
+          },
+        });
+
+        output = createBuilder(
+          eslint.create(input.path(), {
+            console,
+            testGenerator: 'qunit',
+            group: 'app',
+          })
+        );
+
+        yield output.build();
+
+        result = output.read();
+        expect(Object.keys(result)).to.deep.equal(['app.lint-test.js']);
+        expect(result['app.lint-test.js'].trim()).to.equal(
+          [
+            `QUnit.module('ESLint | app');`,
+            ``,
+            `QUnit.test('foo/a.js', function(assert) {`,
+            `  assert.expect(1);`,
+            `  assert.ok(false, 'foo/a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
+            `});`,
+            ``,
+            `QUnit.test('foo/b.js', function(assert) {`,
+            `  assert.expect(1);`,
+            `  assert.ok(true, 'foo/b.js should pass ESLint\\n\\n1:5 - \\'foo\\' is assigned a value but never used. (no-unused-vars)');`,
+            `});`,
+          ].join('\n')
+        );
+
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
+          foo: {
+            'a.js': `console.log('foo');\n`,
+            'b.js': null,
+          },
+        });
+
+        yield output.build();
+
+        result = output.read();
+        expect(Object.keys(result)).to.deep.equal(['app.lint-test.js']);
+        expect(result['app.lint-test.js'].trim()).to.equal(
+          [
+            `QUnit.module('ESLint | app');`,
+            ``,
+            `QUnit.test('foo/a.js', function(assert) {`,
+            `  assert.expect(1);`,
+            `  assert.ok(false, 'foo/a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
+            `});`,
+          ].join('\n')
+        );
+      })
+    );
+
+    it(
+      'mocha: generates a single Mocha test suite',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
           'a.js': `console.log('foo');\n`,
-          'b.js': null,
-        }
-      });
+          'b.js': `var foo = 5;\n`,
+        });
 
-      yield output.build();
+        output = createBuilder(
+          eslint.create(input.path(), {
+            console,
+            testGenerator: 'mocha',
+            group: 'app',
+          })
+        );
 
-      result = output.read();
-      expect(Object.keys(result)).to.deep.equal(['app.lint-test.js']);
-      expect(result['app.lint-test.js'].trim()).to.equal([
-        `QUnit.module('ESLint | app');`,
-        ``,
-        `QUnit.test('foo/a.js', function(assert) {`,
-        `  assert.expect(1);`,
-        `  assert.ok(false, 'foo/a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
-        `});`,
-      ].join('\n'));
-    }));
+        yield output.build();
 
-    it('mocha: generates a single Mocha test suite', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-        'a.js': `console.log('foo');\n`,
-        'b.js': `var foo = 5;\n`,
-      });
-
-      output = createBuilder(eslint.create(input.path(), { console, testGenerator: 'mocha', group: 'app' }));
-
-      yield output.build();
-
-      let result = output.read();
-      expect(Object.keys(result)).to.deep.equal(['app.lint-test.js']);
-      expect(result['app.lint-test.js'].trim()).to.equal([
-        `describe('ESLint | app', function() {`,
-        ``,
-        `  it('a.js', function() {`,
-        `    // test failed`,
-        `    var error = new chai.AssertionError('a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
-        `    error.stack = undefined;`,
-        `    throw error;`,
-        `  });`,
-        ``,
-        `  it('b.js', function() {`,
-        `    // test passed`,
-        `  });`,
-        ``,
-        `});`,
-      ].join('\n'));
-    }));
+        let result = output.read();
+        expect(Object.keys(result)).to.deep.equal(['app.lint-test.js']);
+        expect(result['app.lint-test.js'].trim()).to.equal(
+          [
+            `describe('ESLint | app', function() {`,
+            ``,
+            `  it('a.js', function() {`,
+            `    // test failed`,
+            `    var error = new chai.AssertionError('a.js should pass ESLint\\n\\n1:1 - Unexpected console statement. (no-console)');`,
+            `    error.stack = undefined;`,
+            `    throw error;`,
+            `  });`,
+            ``,
+            `  it('b.js', function() {`,
+            `    // test passed`,
+            `  });`,
+            ``,
+            `});`,
+          ].join('\n')
+        );
+      })
+    );
   });
 
   describe('throwOnError', function() {
-    it('throw an error for the first encountered error', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error' } };\n`,
-        'a.js': `console.log('foo');\n`,
-      });
+    it(
+      'throw an error for the first encountered error',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error' } };\n`,
+          'a.js': `console.log('foo');\n`,
+        });
 
-      output = createBuilder(ESLint.create(input.path(), { console, throwOnError: true }));
+        output = createBuilder(
+          ESLint.create(input.path(), { console, throwOnError: true })
+        );
 
-      yield expect(output.build()).to.be.rejectedWith('rules violation with `error` severity level');
-    }));
+        yield expect(output.build()).to.be.rejectedWith(
+          'rules violation with `error` severity level'
+        );
+      })
+    );
 
-    it('does not throw errors for warning', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'warn' } };\n`,
-        'a.js': `console.log('foo');\n`,
-      });
+    it(
+      'does not throw errors for warning',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'warn' } };\n`,
+          'a.js': `console.log('foo');\n`,
+        });
 
-      output = createBuilder(ESLint.create(input.path(), { console, throwOnError: true }));
+        output = createBuilder(
+          ESLint.create(input.path(), { console, throwOnError: true })
+        );
 
-      yield expect(output.build()).to.be.fulfilled;
-    }));
+        yield expect(output.build()).to.be.fulfilled;
+      })
+    );
 
-    it('does not throw errors for disabled rules', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'off' } };\n`,
-        'a.js': `console.log('foo');\n`,
-      });
+    it(
+      'does not throw errors for disabled rules',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'off' } };\n`,
+          'a.js': `console.log('foo');\n`,
+        });
 
-      output = createBuilder(ESLint.create(input.path(), { console, throwOnError: true }));
+        output = createBuilder(
+          ESLint.create(input.path(), { console, throwOnError: true })
+        );
 
-      yield expect(output.build()).to.be.fulfilled;
-    }));
+        yield expect(output.build()).to.be.fulfilled;
+      })
+    );
   });
 
   describe('throwOnWarn', function() {
-    it('throw an error for the first encountered error', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error' } };\n`,
-        'a.js': `console.log('foo');\n`,
-      });
+    it(
+      'throw an error for the first encountered error',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error' } };\n`,
+          'a.js': `console.log('foo');\n`,
+        });
 
-      output = createBuilder(ESLint.create(input.path(), { console, throwOnWarn: true }));
+        output = createBuilder(
+          ESLint.create(input.path(), { console, throwOnWarn: true })
+        );
 
-      yield expect(output.build()).to.be.rejectedWith('rules violation with `error` severity level');
-    }));
+        yield expect(output.build()).to.be.rejectedWith(
+          'rules violation with `error` severity level'
+        );
+      })
+    );
 
-    it('throw an error for the first encountered warning', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'warn' } };\n`,
-        'a.js': `console.log('foo');\n`,
-      });
+    it(
+      'throw an error for the first encountered warning',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'warn' } };\n`,
+          'a.js': `console.log('foo');\n`,
+        });
 
-      output = createBuilder(ESLint.create(input.path(), { console, throwOnWarn: true }));
+        output = createBuilder(
+          ESLint.create(input.path(), { console, throwOnWarn: true })
+        );
 
-      yield expect(output.build()).to.be.rejectedWith('rules violation with `warn` severity level');
-    }));
+        yield expect(output.build()).to.be.rejectedWith(
+          'rules violation with `warn` severity level'
+        );
+      })
+    );
 
-    it('does not throw errors for disabled rules', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'off' } };\n`,
-        'a.js': `console.log('foo');\n`,
-      });
+    it(
+      'does not throw errors for disabled rules',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'off' } };\n`,
+          'a.js': `console.log('foo');\n`,
+        });
 
-      output = createBuilder(ESLint.create(input.path(), { console, throwOnWarn: true }));
+        output = createBuilder(
+          ESLint.create(input.path(), { console, throwOnWarn: true })
+        );
 
-      yield expect(output.build()).to.be.fulfilled;
-    }));
+        yield expect(output.build()).to.be.fulfilled;
+      })
+    );
   });
 
   describe('.eslintignore', function() {
     // this doesn't seem to work... :(
-    it.skip('excludes files from being linted', co.wrap(function *() {
-      input.write({
-        '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
-        '.eslintignore': `a.js\n`,
-        'a.js': `console.log('foo');\n`,
-        'b.js': `var foo = 5;\n`,
-      });
+    it.skip(
+      'excludes files from being linted',
+      co.wrap(function*() {
+        input.write({
+          '.eslintrc.js': `module.exports = { rules: { 'no-console': 'error', 'no-unused-vars': 'warn' } };\n`,
+          '.eslintignore': `a.js\n`,
+          'a.js': `console.log('foo');\n`,
+          'b.js': `var foo = 5;\n`,
+        });
 
-      output = createBuilder(ESLint.create(input.path(), { console, testGenerator: 'qunit' }));
+        output = createBuilder(
+          ESLint.create(input.path(), { console, testGenerator: 'qunit' })
+        );
 
-      yield output.build();
+        yield output.build();
 
-      let result = output.read();
-      expect(Object.keys(result)).to.deep.equal([
-        '.eslintignore',
-        '.eslintrc.lint-test.js',
-        'b.lint-test.js',
-      ]);
-    }));
+        let result = output.read();
+        expect(Object.keys(result)).to.deep.equal([
+          '.eslintignore',
+          '.eslintrc.lint-test.js',
+          'b.lint-test.js',
+        ]);
+      })
+    );
   });
 });


### PR DESCRIPTION
I'm currently working on merging test trees with in repo addons. [ember-addon-in-repo-tests](https://github.com/sangm/ember-add-in-repo-tests)

 I'm running into issues where `broccoli-lint-eslint` cannot handle multiple nodes. @rwjblue suggested if the `eslintrc` includes `overrides` flag, we can ignore this check.