### PR TITLE
test/run-eslint: Use `p-finally` instead of `.finally()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "chai-as-promised": "^7.0.0",
     "co": "^4.6.0",
     "mocha": "^5.0.0",
+    "p-finally": "^1.0.0",
     "sinon": "^7.0.0",
     "sinon-chai": "^3.2.0"
   },

--- a/test/helpers/run-eslint.js
+++ b/test/helpers/run-eslint.js
@@ -1,4 +1,5 @@
 const broccoli = require('broccoli');
+const pFinally = require('p-finally');
 const eslintValidationFilter = require('../../');
 
 module.exports = function runEslint(path, _options) {
@@ -22,7 +23,7 @@ module.exports = function runEslint(path, _options) {
     outputPath: node.outputPath,
   }));
 
-  promise.finally(() => builder.cleanup());
+  pFinally(promise, () => builder.cleanup());
 
   return promise;
 };


### PR DESCRIPTION
`.finally()` not officially supported in all Node versions and `broccoli` will stop returning RSVP promises in the future

this is the first step towards getting #149 green