### PR TITLE
Default the options param to be empty object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ class EslintValidationFilter extends Filter {
    * @param {{format: String, options: EslintOptions}} options Filter options
    * @returns {EslintValidationFilter} Filter obconfig @constructor
    */
-  constructor(inputNode, options) {
+  constructor(inputNode, options = {}) {
     let _console = options.console || console;
 
     if (!options[FACTORY_METHOD_USED]) {

--- a/test/eslint-test.js
+++ b/test/eslint-test.js
@@ -471,4 +471,14 @@ describe('broccoli-lint-eslint', function() {
       'b.lint-test.js'
     ]);
   }));
+
+  describe('use new ESLint', function() {
+    it('throw an error for usage without options', co.wrap(function () {
+      debugger
+      expect(function() {
+        new ESLint(input.path())
+      }).to.throw('Please use the create() factory method instead of ' +
+        'calling ESLint() directly or using new ESLint()');
+    }));
+  });
 });


### PR DESCRIPTION
Code:
```js
new EslintValidationFilter('tests')
```
Error:
```
TypeError: Cannot read property 'console' of undefined
    at new EslintValidationFilter (/Users/snrai/Projects/broccoli-tester/node_modules/broccoli-lint-eslint/lib/index.js:46:28)
    at Object.<anonymous> (/Users/snrai/Projects/broccoli-tester/Brocfile.js:7:12)
    at Generator.next (<anonymous>)

```

Fixes:

1) calling new with no options will crash with a console of undefined
2) default to empty so that we can display an error message to use `create`